### PR TITLE
Add workspace selector and switcher UI

### DIFF
--- a/monitor/internal/tui/app/app.go
+++ b/monitor/internal/tui/app/app.go
@@ -256,8 +256,37 @@ func (a *App) StatusLine() string {
 	}
 	conn := a.Store.ConnectionState().String()
 	status := a.Store.Status()
-	if status.MilestoneName != "" {
-		return fmt.Sprintf("[%s] M%d: %s (%s)", conn, status.MilestoneID, status.MilestoneName, status.Phase)
+	ws := a.Store.CurrentWorkspace()
+	prefix := conn
+	if ws != "" {
+		prefix = fmt.Sprintf("%s | WS:%s", conn, ws)
 	}
-	return fmt.Sprintf("[%s]", conn)
+	if status.MilestoneName != "" {
+		return fmt.Sprintf("[%s] M%d: %s (%s)", prefix, status.MilestoneID, status.MilestoneName, status.Phase)
+	}
+	return fmt.Sprintf("[%s]", prefix)
+}
+
+// CycleWorkspace switches to the next workspace (wraps around).
+// If no workspaces are configured, this is a no-op.
+func (a *App) CycleWorkspace() {
+	if a.Store == nil {
+		return
+	}
+	workspaces := a.Store.Workspaces()
+	if len(workspaces) == 0 {
+		return
+	}
+	current := a.Store.CurrentWorkspace()
+	idx := -1
+	for i, ws := range workspaces {
+		if ws == current {
+			idx = i
+			break
+		}
+	}
+	// Move to next (or first if current not found)
+	next := (idx + 1) % len(workspaces)
+	a.Store.SetCurrentWorkspace(workspaces[next])
+	a.notifyUpdate()
 }

--- a/monitor/internal/tui/components/root.go
+++ b/monitor/internal/tui/components/root.go
@@ -144,6 +144,11 @@ func (r *Root) KeyMap() tui.KeyMap {
 		}
 	})))
 
+	// Workspace switcher (v2)
+	km = append(km, tui.On(tui.Rune('w'), dirty(func(ke tui.KeyEvent) {
+		r.app.CycleWorkspace()
+	})))
+
 	// Number keys: direct tab selection, generated from AllTabs()
 	// so bindings stay in sync if tabs are reordered or added.
 	for i, tab := range app.AllTabs() {
@@ -173,6 +178,7 @@ func (r *Root) buildHelpOverlay() *tui.Element {
 	bindings := []struct{ key, desc string }{
 		{"1-4", "Switch to tab"},
 		{"Tab / Shift+Tab", "Cycle tabs"},
+		{"w", "Switch workspace"},
 		{"j / k", "Navigate list"},
 		{"G", "Jump to last"},
 		{"g g", "Jump to first"},

--- a/monitor/internal/tui/state/state.go
+++ b/monitor/internal/tui/state/state.go
@@ -21,6 +21,10 @@ type Store struct {
 	connState    client.ConnectionState
 	lastEventID  string
 	dirty        map[string]bool // resource -> needs refresh
+
+	// Workspace support (v2)
+	currentWorkspace string
+	workspaces       []string
 }
 
 // NewStore returns an initialised Store.
@@ -197,4 +201,33 @@ func resourceForEvent(eventType string) string {
 	default:
 		return ""
 	}
+}
+
+// ── Workspace (v2) ────────────────────────────────────────────────────
+
+func (s *Store) SetCurrentWorkspace(ws string) {
+	s.mu.Lock()
+	s.currentWorkspace = ws
+	s.mu.Unlock()
+}
+
+func (s *Store) CurrentWorkspace() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.currentWorkspace
+}
+
+func (s *Store) SetWorkspaces(workspaces []string) {
+	s.mu.Lock()
+	s.workspaces = make([]string, len(workspaces))
+	copy(s.workspaces, workspaces)
+	s.mu.Unlock()
+}
+
+func (s *Store) Workspaces() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]string, len(s.workspaces))
+	copy(out, s.workspaces)
+	return out
 }


### PR DESCRIPTION
## Summary

Implements workspace selector and switcher UI for TUI v2 (issue-3-1).

- Add workspace state management (current workspace, workspace list)
- Add 'w' keyboard shortcut for cycling through workspaces  
- Display current workspace in status bar
- Update help overlay with workspace switching documentation

## Changes

**State management** (`internal/tui/state/state.go`):
- Added `currentWorkspace` and `workspaces` fields to Store
- Added thread-safe getters/setters for workspace state

**Keyboard shortcuts** (`internal/tui/components/root.go`):
- Added 'w' key binding to trigger workspace cycling
- Updated help overlay to document workspace switching

**Status display** (`internal/tui/app/app.go`):
- Modified StatusLine to show current workspace (WS:<name>)
- Implemented CycleWorkspace method for switching workspaces

## Test Plan

- Manual testing: run TUI and verify 'w' key cycles workspaces
- Verify current workspace displays in status bar
- Verify help overlay shows workspace shortcut

Part of milestone 3: TUI v2 Visualization