### PR TITLE
Fix .gitignore to exclude Ratchet runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@ result
 result-*
 .claude/commands/ratchet/
 .claude/ratchet-scripts/
+
+# Ratchet: Exclude all runtime state, then include config
 .ratchet/*
 !.ratchet/workflow.yaml
 !.ratchet/project.yaml
-!.ratchet/plan.yaml
 !.ratchet/pairs/


### PR DESCRIPTION
## Summary

Fixes .gitignore to properly exclude Ratchet runtime state files from version control.

### Changes

- Removed explicit inclusion of plan.yaml which was versioning runtime state
- Runtime state files now correctly excluded via .ratchet/* wildcard  
- Configuration files (workflow.yaml, project.yaml, pairs/) remain included

### Context

Runtime state files (plan.yaml, debates/, guards/, etc.) were being committed to version control, causing noise in PRs. These files are analogous to .git internals and should not be versioned.

### Debate Summary

Pair: script-robustness
Phase: review
Rounds: 1
Verdict: ACCEPT (consensus)
Debate ID: issue-6-1-script-robustness-20260316T211709

The adversarial agent verified the fix correctly excludes runtime state while preserving config files, using a future-proof wildcard pattern.

### Note

Existing tracked plan.yaml files in current PRs will need manual cleanup - that cleanup is tracked separately.

Closes #15