### PR TITLE
Debate-runner posts round comments (v2 — rebased)

### DIFF
--- a/agents/debate-runner.md
+++ b/agents/debate-runner.md
@@ -95,6 +95,8 @@ Context:
 
 **Publish field defaults:** If the `Publish:` block is absent from the task context (e.g., orchestrators that predate this feature), treat all fields as their defaults: `publish_debates = false`, `progress_ref = null`, `adapter = "none"`. No comments are posted and no warnings are emitted.
 
+> **Forward reference:** The `/ratchet:run` skill learns to populate these Publish fields in [issue 45].
+
 ## Progress Reporting
 
 The debate-runner operates inside the orchestrator's TodoWrite context. Use TodoWrite to report debate progress so users see real-time status in their terminal.


### PR DESCRIPTION
## Summary
Re-run of issue #44 from current main after merge conflict on original PR #49.

All #44 features were already present from prior merged PRs (#48, #50, #51, #53). This PR adds only the forward-reference to issue 45 that was identified during the skill-coherence review.

Replaces #49 (conflicting).

## Debate Summary

| Pair | Phase | Rounds | Verdict |
|------|-------|--------|---------|
| agent-effectiveness | review | 1 | ACCEPT |
| skill-coherence | review | 1 | ACCEPT |

Both pairs confirmed all 8 acceptance criteria already met. Minimal delta.

Closes #44