### PR TITLE
Inject baseline validation state into adversarial agent prompts

### DIFF
--- a/.ratchet/pairs/agent-effectiveness/adversarial.md
+++ b/.ratchet/pairs/agent-effectiveness/adversarial.md
@@ -95,6 +95,37 @@ For each agent (analyst, debate-runner, tiebreaker):
 - [ ] **Concrete examples required (8 occurrences - 62% of debates)**: Flag abstract instructions without concrete examples (e.g., "create metadata" needs JSON snippet)
 - [ ] **Fix completeness declaration (new - from review suggestion 6)**: Verify the generative included an explicit fix tally at the end of their round: "N issues identified, M fixed, K deferred." If missing, or if the count doesn't match what you observe in the diff, REJECT. This prevents silent omissions.
 
+## Baseline Validation State (Injected at Spawn Time)
+
+The debate-runner injects live validation output here when spawning this agent.
+This section documents the injection spec — the actual output appears in the
+spawn prompt, not in this static file.
+
+**Why not $() in this file**: $() blocks only expand in slash commands loaded
+at session start. This file is loaded via the Agent tool at runtime, where $()
+is NOT expanded. Injection must happen in the debate-runner's spawn prompt string.
+
+**Baseline commands the debate-runner runs before spawning** (output capped at 30 lines each):
+```bash
+# Verify agent files parse as valid markdown (check they exist and are readable)
+ls agents/*.md 2>&1 | tail -30
+
+# Verify pair definitions exist
+ls .ratchet/pairs/*/adversarial.md .ratchet/pairs/*/generative.md 2>&1 | tail -30
+
+# Verify debate metadata structure
+cat .ratchet/debates/*/meta.json | jq 'keys' 2>&1 | tail -30
+```
+
+**How to use the injected baseline**:
+- If baseline shows files were already missing → generative must not make it worse
+- If baseline shows clean state → any new error (missing file, broken reference) is a REJECT
+- If baseline is absent → run the commands above yourself to establish current state
+
+**Live validation during rounds still applies** — run cross-reference checks and
+tool list verification yourself each round. The baseline supplements (does not
+replace) live validation.
+
 ## Cross-Reference Validation (Always Run) - ENHANCED
 
 Before accepting ANY agent, verify external dependencies and format compatibility:

--- a/.ratchet/pairs/schema-correctness/adversarial.md
+++ b/.ratchet/pairs/schema-correctness/adversarial.md
@@ -161,6 +161,34 @@ grep -r "$field.*value\|$field.*option" agents/ skills/ pairs/
 
 **REJECT immediately if any enum is incomplete.** This is non-negotiable.
 
+## Baseline Validation State (Injected at Spawn Time)
+
+The debate-runner injects live validation output here when spawning this agent.
+This section documents the injection spec — the actual output appears in the
+spawn prompt, not in this static file.
+
+**Why not $() in this file**: $() blocks only expand in slash commands loaded
+at session start. This file is loaded via the Agent tool at runtime, where $()
+is NOT expanded. Injection must happen in the debate-runner's spawn prompt string.
+
+**Baseline commands the debate-runner runs before spawning** (output capped at 30 lines each):
+```bash
+# Schema syntax validity — captures pre-change parse state
+jq empty schemas/workflow.schema.json 2>&1 | tail -30
+
+# Real config validation against schema — captures pre-change compliance state
+nix develop --command bash -c 'yq -o=json .ratchet/workflow.yaml | jq empty' 2>&1 | tail -30
+```
+
+**How to use the injected baseline**:
+- If baseline shows schema was already invalid → generative must prove their
+  changes didn't make it worse; fix pre-existing issues too
+- If baseline shows zero errors → any new error is a REJECT
+- If baseline is absent → run `jq empty schemas/workflow.schema.json` yourself
+
+**Live validation during rounds still applies** — run jq/yq commands yourself
+each round. The baseline supplements (does not replace) live validation.
+
 ## Validation Commands
 
 **Check syntax**:

--- a/.ratchet/pairs/script-robustness/adversarial.md
+++ b/.ratchet/pairs/script-robustness/adversarial.md
@@ -112,6 +112,35 @@ For each script, verify:
 **Examples must be runnable (8 occurrences - 62% of debates):**
 - [ ] Ensure usage examples are concrete and runnable, not abstract
 
+## Baseline Validation State (Injected at Spawn Time)
+
+The debate-runner injects live validation output here when spawning this agent.
+This section documents the injection spec — the actual output appears in the
+spawn prompt, not in this static file.
+
+**Why not $() in this file**: $() blocks only expand in slash commands loaded
+at session start. This file is loaded via the Agent tool at runtime, where $()
+is NOT expanded. Injection must happen in the debate-runner's spawn prompt string.
+
+**Baseline commands the debate-runner runs before spawning** (output capped at 30 lines each):
+```bash
+# Shellcheck — captures pre-change violation state
+nix develop --command shellcheck scripts/**/*.sh install.sh 2>&1 | tail -30
+
+# Checkbashisms — captures pre-change portability state (sh scripts only)
+checkbashisms scripts/*.sh 2>&1 | grep -v "does not appear to have a #! interpreter line" | tail -30
+```
+
+**How to use the injected baseline**:
+- If baseline shows shellcheck was already failing → generative must prove their
+  changes didn't make it worse, not just that it passes now
+- If baseline shows zero violations → any new violation is a REJECT
+- If baseline is absent (debate-runner didn't inject) → treat as unknown; run
+  shellcheck yourself to establish current state
+
+**Live validation during rounds still applies** — run shellcheck and checkbashisms
+yourself each round. The baseline supplements (does not replace) live validation.
+
 ## Pre-Debate Verification (Run FIRST)
 
 **CRITICAL**: Before reviewing any scripts, verify shellcheck guard passed:

--- a/.ratchet/pairs/skill-coherence/adversarial.md
+++ b/.ratchet/pairs/skill-coherence/adversarial.md
@@ -72,6 +72,37 @@ The user prioritized ALL of:
   - Conditional logic → Must show if/then/else pattern
   - No abstract "do X" without showing HOW
 
+## Baseline Validation State (Injected at Spawn Time)
+
+The debate-runner injects live validation output here when spawning this agent.
+This section documents the injection spec — the actual output appears in the
+spawn prompt, not in this static file.
+
+**Why not $() in this file**: $() blocks only expand in slash commands loaded
+at session start. This file is loaded via the Agent tool at runtime, where $()
+is NOT expanded. Injection must happen in the debate-runner's spawn prompt string.
+
+**Baseline commands the debate-runner runs before spawning** (output capped at 30 lines each):
+```bash
+# Workflow schema syntax — captures pre-change schema validity
+jq empty schemas/workflow.schema.json 2>&1 | tail -30
+
+# Real config parses cleanly — captures pre-change config health
+nix develop --command bash -c 'yq -o=json .ratchet/workflow.yaml | jq empty' 2>&1 | tail -30
+
+# Cross-reference: verify skill files exist
+ls skills/*/SKILL.md 2>&1 | tail -30
+```
+
+**How to use the injected baseline**:
+- If baseline shows config was already broken → generative must not make it worse
+- If baseline shows clean state → any new error is a REJECT
+- If baseline is absent → run the commands above yourself to establish current state
+
+**Live validation during rounds still applies** — run cross-reference checks and
+schema validation yourself each round. The baseline supplements (does not replace)
+live validation.
+
 ## Cross-Reference Validation (Always Run)
 
 Before accepting ANY skill, verify external dependencies:

--- a/agents/analyst.md
+++ b/agents/analyst.md
@@ -82,7 +82,7 @@ Based on the scan + interview, identify:
 - What the human cares about improving
 - What validation commands are available (exact commands, discovered from the codebase)
 
-Record all discovered validation commands — adversarial agents need to know exactly what they can run. These commands must be included in each adversarial agent's "Validation Commands" section.
+Record all discovered validation commands — adversarial agents need to know exactly what they can run. These commands must be included in each adversarial agent's "Validation Commands" section. They are also written to `project.yaml` under `testing.layers.*.command` so the debate-runner can auto-discover them at spawn time to inject baseline validation state into adversarial agent prompts.
 
 **Handling Discrepancies:**
 If the scan and interview reveal conflicting information (e.g., human says "we have comprehensive tests" but scan found no test files):
@@ -370,11 +370,51 @@ You are the **critic** in the {pair-name} quality pair.
 - NEVER output plain-text questions — if you need clarification, state it as a finding
 - **Enforce guilty-until-proven-innocent** — if the generative claims a test failure is "pre-existing" or "unrelated," demand proof (must show the same failure on main). Without proof, REJECT.
 
+## Baseline Validation State
+
+**DEBATE-RUNNER INJECTION POINT** — When spawning this adversarial agent via the
+Agent tool, the debate-runner MUST prepend the following block to the spawn prompt:
+
+```
+## Baseline Validation State (at debate start)
+The following output was captured before any changes were made.
+Use it as your before-state when evaluating whether changes introduced
+regressions or fixed existing failures.
+
+<output of each baseline_validation_command, capped with 2>&1 | tail -30>
+```
+
+**How the debate-runner discovers the commands**: Read `.ratchet/project.yaml`
+under `testing.layers.*.command` for each layer with `status: planned` or
+`status: applicable`. Run each command with `2>&1 | tail -30` to capture output.
+Example:
+
+```bash
+# From project.yaml testing.layers (skips layers with no command field):
+yq '.testing.layers | to_entries[] | select(.value.status == "planned" or .value.status == "applicable") | .value.command | select(. != null)' \
+  .ratchet/project.yaml | while read -r cmd; do
+    echo "=== $cmd ==="
+    eval "$cmd" 2>&1 | tail -30
+done
+```
+
+**Why not $()**: $() blocks only expand in slash commands loaded at session
+start. Adversarial agents are spawned via the Agent tool at runtime — $() in
+static .md files is NOT expanded. Injection must happen in the spawn prompt
+string itself, not in this template file.
+
+**Baseline command list** (fill from `project.yaml testing.layers` during init):
+{List each discovered command exactly, one per line — e.g.:}
+{  cd /path/to/project && npm test 2>&1 | tail -30}
+{  cd /path/to/project && npm run lint 2>&1 | tail -30}
+
 ## Validation Commands
 {List the exact commands this agent can run, discovered from the project's actual tooling:}
 {- Each command with a brief description of what it checks}
 {- Only include commands that actually exist in this project}
 {- If no commands exist yet, note that and focus on code review}
+{- These commands are run LIVE during each debate round and supplement the}
+{- baseline state injected at spawn time — they are NOT replaced by it}
 
 ## Project Context
 {Relevant project-specific details}


### PR DESCRIPTION
## Summary
- Analyst template: added Baseline Validation State section with debate-runner injection point
- Key design: uses plain-text instructions (not $() blocks) because Agent-spawned prompts don't expand shell interpolation
- Updated all 4 adversarial pairs with project-specific baseline commands:
  - script-robustness: shellcheck, checkbashisms
  - schema-correctness: jq empty, yq+jq config validation
  - skill-coherence: schema validity, config parse, skill file existence
  - agent-effectiveness: agent file listing, pair definitions, debate metadata

## Debate Summary

| Pair | Phase | Rounds | Verdict |
|------|-------|--------|---------|
| agent-effectiveness | review | 3 | ACCEPT |

R1: HTML comments invisible to debate-runner, non-existent field reference. R2: yq null passthrough. All fixed.

Depends on #61 being merged first.
Closes #58