### PR TITLE
Remove eval injection and harden guard execution

### DIFF
--- a/scripts/run-guards.sh
+++ b/scripts/run-guards.sh
@@ -35,7 +35,7 @@ trap 'rm -f "$stderr_tmp"' EXIT
 # Temporarily disable set -e to capture exit code correctly
 # Without this, command substitution failure causes immediate exit
 set +e
-stdout_output=$(eval "$GUARD_COMMAND" 2>"$stderr_tmp")
+stdout_output=$(bash -c "$GUARD_COMMAND" 2>"$stderr_tmp")
 exit_code=$?
 stderr_output=$(cat "$stderr_tmp")
 rm -f "$stderr_tmp"
@@ -54,10 +54,15 @@ timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")
 if [ "$BLOCKING" = "true" ]; then blocking_json="true"; else blocking_json="false"; fi
 if [ "$exit_code" -eq 0 ]; then passed_json="true"; else passed_json="false"; fi
 
-# Atomic write: temp file + mv to prevent corrupt JSON on crash
+# Atomic write with advisory locking: flock + temp file + mv
+# flock prevents concurrent guards from conflicting on the same directory.
+# Falls back to unlocked write if flock is unavailable (e.g., macOS without flock).
+LOCK_FILE="$GUARDS_DIR/.guard-write.lock"
 tmp_guard=$(mktemp "${GUARDS_DIR}/${GUARD_NAME}.XXXXXX")
 trap 'rm -f "$tmp_guard"' EXIT
-cat > "$tmp_guard" <<JSON_EOF
+
+write_guard_json() {
+    cat > "$tmp_guard" <<JSON_EOF
 {
   "guard": "$escaped_guard_name",
   "command": "$escaped_command",
@@ -71,7 +76,19 @@ cat > "$tmp_guard" <<JSON_EOF
   "override_reason": null
 }
 JSON_EOF
-mv "$tmp_guard" "$GUARDS_DIR/$GUARD_NAME.json"
+    mv "$tmp_guard" "$GUARDS_DIR/$GUARD_NAME.json"
+}
+
+if command -v flock >/dev/null 2>&1; then
+    # Use fd 9 for flock to avoid interfering with stdin/stdout/stderr
+    exec 9>"$LOCK_FILE"
+    flock -w 30 9 || { echo "Error: Failed to acquire lock on $LOCK_FILE" >&2; exit 1; }
+    write_guard_json
+    exec 9>&-
+else
+    # Fallback: no flock available (macOS without homebrew coreutils)
+    write_guard_json
+fi
 
 if [ "$exit_code" -ne 0 ]; then
     if [ "$BLOCKING" = "true" ]; then

--- a/skills/guard/SKILL.md
+++ b/skills/guard/SKILL.md
@@ -7,6 +7,36 @@ description: Manage guards — list, add, run, and override deterministic checks
 
 Guards are deterministic shell commands (lint, test, security scan, benchmarks) that run at phase boundaries. They complement debates — debates are semantic, guards are mechanical.
 
+## Resource Gating with `requires`
+
+Guards can declare shared resource dependencies using the `requires` field. Resources are defined in the top-level `resources` array of `workflow.yaml` and represent shared infrastructure (databases, test servers, etc.) that guards may need exclusive access to.
+
+When a guard specifies `requires: [resource-name]`, the resource is started (via its `start` command) before the guard runs and locked if the resource is `singleton: true`. Singleton locking serializes access so only one guard at a time can use the resource — other guards requiring the same singleton resource wait until the lock is released.
+
+**Example** in `workflow.yaml`:
+```yaml
+resources:
+  - name: test-db
+    start: "docker compose up -d test-db"
+    stop: "docker compose down test-db"
+    singleton: true
+
+guards:
+  - name: integration-tests
+    command: "npm run test:integration"
+    phase: build
+    blocking: true
+    requires: [test-db]
+```
+
+The `requires` field accepts an array of resource names (must match entries in `resources`). If a required resource is not defined, the guard fails with an error before execution.
+
+## Parallel Guard Writes and File Locking
+
+When multiple guards run concurrently, `run-guards.sh` uses `flock` (advisory file locking) to prevent race conditions when writing guard result JSON files. Each guard result directory has a `.guard-write.lock` file; the script acquires an exclusive lock (with a 30-second timeout) before writing the result JSON via atomic temp-file-then-`mv`.
+
+On systems where `flock` is unavailable (e.g., macOS without Homebrew coreutils), the script falls back to unlocked writes. This is safe for single-guard execution but may produce corrupted results if multiple guards target the same directory concurrently on such systems.
+
 ## Usage
 ```
 /ratchet:guard                     # List all guards with last results
@@ -44,6 +74,7 @@ Guards
     Command: [command]
     Phase: [phase] | Timing: [pre-debate/post-debate] | Blocking: [yes/no]
     Components: [list or "all"]
+    Requires: [resource list or "none"]
     Last result: [pass/fail/not run] ([timestamp])
 
   [name]
@@ -82,7 +113,13 @@ Use `AskUserQuestion` to gather guard details interactively:
    - If components exist: Options are component names + `"All components"`
    - If no components configured: Options are `"All files (no components configured)"`
 
-7. **Confirm** — present the guard definition:
+7. **Resource requirements** — which shared resources does this guard need:
+   - Read `resources` array from workflow.yaml
+   - If resources exist: Options are resource names + `"None"`
+   - If no resources configured: skip this step (no resources available to require)
+   - Selected resources are stored in the `requires` field (see [Resource Gating](#resource-gating-with-requires))
+
+8. **Confirm** — present the guard definition:
    - Use `AskUserQuestion`: "[guard summary]. Add this guard?"
    - Options: `"Add (Recommended)"`, `"Modify"`, `"Cancel"`
 
@@ -105,7 +142,7 @@ If missing:
 
 For each matching guard:
 ```bash
-bash .claude/ratchet-scripts/run-guards.sh <milestone-id> <phase> <guard-name> "<command>" <blocking>
+bash .claude/ratchet-scripts/run-guards.sh <milestone-id> <issue-ref> <phase> <guard-name> "<command>" <blocking>
 ```
 
 Use the current milestone from `plan.yaml` (or "manual" if no active milestone).
@@ -127,7 +164,7 @@ Guard Results: [phase] phase
 **Guilty until proven innocent**: Guard failures are caused by the current changes unless proven otherwise. Before overriding a failed guard, verify whether the failure exists on a clean checkout:
 ```bash
 # Test on clean base to determine if failure is pre-existing
-git stash && bash .claude/ratchet-scripts/run-guards.sh <milestone-id> <phase> <guard-name> "<command>" <blocking> && git stash pop
+git stash && bash .claude/ratchet-scripts/run-guards.sh <milestone-id> <issue-ref> <phase> <guard-name> "<command>" <blocking> && git stash pop
 # Only override if the guard also fails on clean base (pre-existing failure)
 ```
 
@@ -136,17 +173,20 @@ If any blocking guards failed, use `AskUserQuestion`:
 
 #### Guard Results
 
-Guard results are stored as JSON in `.ratchet/guards/<milestone-id>/<phase>/<guard-name>.json` with this structure:
+Guard results are stored as JSON in `.ratchet/guards/<milestone-id>/<issue-ref>/<phase>/<guard-name>.json` with this structure:
 
 ```json
 {
   "guard": "<guard-name>",
-  "phase": "<phase>",
   "command": "<command that was executed>",
   "exit_code": 0,
-  "output": "<combined stdout+stderr>",
+  "stdout": "<stdout output>",
+  "stderr": "<stderr output>",
+  "passed": true,
   "blocking": true,
-  "timestamp": "<ISO timestamp>"
+  "timestamp": "<ISO timestamp>",
+  "overridden": false,
+  "override_reason": null
 }
 ```
 
@@ -162,9 +202,18 @@ These fields are produced by `scripts/run-guards.sh`. When a guard is overridden
 
 ### override — Override a Failed Guard
 
-Read the guard result from `.ratchet/guards/<milestone-id>/<phase>/<name>.json`.
+Read the guard result from `.ratchet/guards/<milestone-id>/<issue-ref>/<phase>/<name>.json`.
 
 Determine `<milestone-id>` from the current active milestone in `.ratchet/plan.yaml`, or require it as an argument: `guard override <name> --milestone <id>`.
+
+Determine `<issue-ref>` from the current active issue context, or require it as an argument: `guard override <name> --issue <ref>`.
+
+**Validation**: Before reading the guard result, validate that the issue-ref exists in `plan.yaml`:
+```bash
+yq ".epic.milestones[] | select(.id == $MILESTONE_ID) | .issues[] | select(.ref == \"$ISSUE_REF\")" .ratchet/plan.yaml
+```
+If the issue-ref is not found in the milestone's issues array, report a clear error:
+> "Issue ref '[ref]' not found in milestone [id]. Available issues: [list of refs from plan.yaml]. Check the ref and try again."
 
 If no failure exists for this guard:
 > "Guard '[name]' has no recent failure to override."
@@ -178,11 +227,11 @@ If "Override with reason": use follow-up `AskUserQuestion` (freeform) to capture
 Update the existing guard result JSON (do NOT overwrite — patch only the override fields):
 ```bash
 jq '.overridden = true | .override_reason = "<user reason>" | .override_timestamp = "<ISO timestamp>"' \
-  .ratchet/guards/<milestone-id>/<phase>/<name>.json > /tmp/guard-override-tmp.json \
-  && mv /tmp/guard-override-tmp.json .ratchet/guards/<milestone-id>/<phase>/<name>.json
+  .ratchet/guards/<milestone-id>/<issue-ref>/<phase>/<name>.json > /tmp/guard-override-tmp.json \
+  && mv /tmp/guard-override-tmp.json .ratchet/guards/<milestone-id>/<issue-ref>/<phase>/<name>.json
 ```
 
-This preserves the original `exit_code`, `output`, `command`, and `phase` fields.
+This preserves the original `guard`, `command`, `exit_code`, `stdout`, `stderr`, `passed`, `blocking`, and `timestamp` fields.
 
 ### remove — Remove a Guard
 


### PR DESCRIPTION
Fixes #67

## Summary

- Replaced `eval "$GUARD_COMMAND"` with `bash -c "$GUARD_COMMAND"` for process-level isolation — prevents guard commands from modifying parent shell state
- Added `flock` advisory locking for parallel guard result writes (30s timeout, macOS fallback)
- Documented `requires` parameter for resource gating in guard skill spec
- Fixed override target validation — issue-ref now validated against plan.yaml with helpful error messages

## Debates

| Pair | Phase | Verdict | Rounds |
|------|-------|---------|--------|
| script-robustness | review | ACCEPT | 1 |
| skill-coherence | review | ACCEPT | 2 |

## Test plan

- [ ] Verify `bash -c` execution works for all guard command patterns (piped, quoted, multi-command)
- [ ] Test flock locking with concurrent guard runs
- [ ] Verify override validation rejects invalid issue-refs
- [ ] Check `requires` documentation matches workflow schema