### PR TITLE
Harden utility scripts (cache-check, check-generated-files, publish-debate-hook)

### DIFF
--- a/scripts/cache-check.sh
+++ b/scripts/cache-check.sh
@@ -33,6 +33,16 @@ matched_files=""
 IFS=',' read -ra globs <<< "$SCOPE_GLOB"
 for glob in "${globs[@]}"; do
     glob="$(echo "$glob" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s|\*\*/|*|g;s|\*\*|*|g')"
+    # Validate glob pattern: must contain only safe characters for find -path
+    # Reject empty patterns or patterns with characters that could cause issues
+    if [ -z "$glob" ]; then
+        echo "Warning: empty glob pattern skipped" >&2
+        continue
+    fi
+    if [[ "$glob" =~ [[:cntrl:]] ]] || [[ "$glob" == *$'\n'* ]]; then
+        echo "Warning: glob pattern contains control characters, skipped: $glob" >&2
+        continue
+    fi
     matches=$(find . -path "./$glob" -type f 2>/dev/null || true)
     if [ -n "$matches" ]; then
         matched_files="${matched_files:+${matched_files}

--- a/scripts/check-generated-files.sh
+++ b/scripts/check-generated-files.sh
@@ -68,8 +68,8 @@ detect_stack_patterns() {
     local content
     content=$(cat "$project_file")
 
-    # Go ecosystem
-    if printf '%s' "$content" | grep -qi '\bgo\b'; then
+    # Go ecosystem (matches: go, golang, Go, Golang)
+    if printf '%s' "$content" | grep -qiE '\b(go|golang)\b'; then
         STACK_PATH_PATTERNS+=(
             '_templ.go'           # templ generated components
             '.pb.go'              # protobuf generated code

--- a/scripts/publish-debate-hook.sh
+++ b/scripts/publish-debate-hook.sh
@@ -25,11 +25,11 @@ ARTIFACT_TYPE=""
 case "$FILE_PATH" in
     */.ratchet/debates/*/rounds/round-*-generative.md)
         ARTIFACT_TYPE="generative"
-        DEBATE_DIR=$(echo "$FILE_PATH" | sed 's|/rounds/round-.*||')
+        DEBATE_DIR="${FILE_PATH%%/rounds/round-*}"
         ;;
     */.ratchet/debates/*/rounds/round-*-adversarial.md)
         ARTIFACT_TYPE="adversarial"
-        DEBATE_DIR=$(echo "$FILE_PATH" | sed 's|/rounds/round-.*||')
+        DEBATE_DIR="${FILE_PATH%%/rounds/round-*}"
         ;;
     */.ratchet/debates/*/meta.json)
         # Final meta.json write — check if debate just completed for summary publish
@@ -56,17 +56,19 @@ STATUS=$(jq -r '.status // empty' "$META_FILE" 2>/dev/null) || true
 
 # --- Locate workflow.yaml to read publish config ---
 # Walk up from the debate directory to find .ratchet/workflow.yaml
-RATCHET_DIR=$(echo "$DEBATE_DIR" | sed 's|/.ratchet/debates/.*|/.ratchet|')
+RATCHET_DIR="${DEBATE_DIR%%/.ratchet/debates/*}/.ratchet"
 PROJECT_DIR=$(dirname "$RATCHET_DIR")
 WORKFLOW_FILE="$RATCHET_DIR/workflow.yaml"
 
 if [ ! -f "$WORKFLOW_FILE" ]; then
+    echo "Warning: publish-debate-hook: workflow.yaml not found at $WORKFLOW_FILE — debate publishing disabled" >&2
     exit 0
 fi
 
 # Read publish config from workflow.yaml
-# Requires yq — fall back silently if unavailable
+# Requires yq — fall back with warning if unavailable
 if ! command -v yq >/dev/null 2>&1; then
+    echo "Warning: publish-debate-hook: yq not found — debate publishing disabled (install yq to enable)" >&2
     exit 0
 fi
 


### PR DESCRIPTION
Fixes #69

## Summary

- Added glob pattern validation to `cache-check.sh` — guards against empty and malformed patterns causing false cache invalidations
- Extended Go stack detection in `check-generated-files.sh` from `\bgo\b` to `\b(go|golang)\b`
- Added stderr warnings to `publish-debate-hook.sh` when workflow.yaml is missing or yq unavailable (exit codes unchanged)
- Fixed 3 shellcheck SC2001 warnings by replacing `echo|sed` with parameter expansion

## Debates

| Pair | Phase | Verdict | Rounds |
|------|-------|---------|--------|
| script-robustness | review | ACCEPT | 1 |

## Test plan

- [ ] Verify cache-check.sh rejects empty/malformed glob patterns
- [ ] Verify check-generated-files.sh detects Go stack with `golang` variant
- [ ] Verify publish-debate-hook.sh logs warnings to stderr when yq missing
- [ ] All scripts pass shellcheck