### PR TITLE
Harden create-issue.sh error handling

### DIFF
--- a/scripts/progress/github-issues/create-issue.sh
+++ b/scripts/progress/github-issues/create-issue.sh
@@ -55,21 +55,20 @@ fi
 ISSUE_BODY="${ISSUE_BODY}---
 <!-- ratchet-managed -->"
 
-# Build label args
-LABEL_ARGS=""
+# Build label args as array to handle labels with spaces correctly
+LABEL_ARGS=()
 for label in "${LABELS[@]}"; do
-    LABEL_ARGS="${LABEL_ARGS} --label ${label}"
+    LABEL_ARGS+=(--label "$label")
 done
 
 # Create the issue and extract the number
-# shellcheck disable=SC2086
-ISSUE_URL=$(gh issue create --title "$TITLE" --body "$ISSUE_BODY" $LABEL_ARGS 2>/dev/null) || {
-    echo "Error: Failed to create GitHub issue" >&2
+ISSUE_URL=$(gh issue create --title "$TITLE" --body "$ISSUE_BODY" ${LABEL_ARGS[@]+"${LABEL_ARGS[@]}"} 2>&1) || {
+    echo "Error: Failed to create GitHub issue: $ISSUE_URL" >&2
     exit 1
 }
 
 # Extract issue number from URL (https://github.com/owner/repo/issues/123)
-ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$') || true
 
 if [ -z "$ISSUE_NUM" ]; then
     echo "Error: Could not parse issue number from: $ISSUE_URL" >&2


### PR DESCRIPTION
Fixes #70

## Summary

- Fixed word splitting on label arguments by switching to array pattern matching `create-item.sh`
- Exposed `gh` CLI stderr (was `2>/dev/null`, now `2>&1`) so error details are visible
- Added `|| true` guard on `grep -oE` under `set -e` for consistency with sibling scripts

## Debates

| Pair | Phase | Verdict | Rounds |
|------|-------|---------|--------|
| script-robustness | review | ACCEPT | 1 |

## Test plan

- [ ] Verify create-issue.sh label handling with multi-word labels
- [ ] Verify gh CLI errors are visible in output
- [ ] All progress adapter scripts pass shellcheck