### PR TITLE
Fix workflow schema gaps and document all valid values

### DIFF
--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -32,7 +32,7 @@
       "type": "string",
       "enum": ["human", "tiebreaker", "both", "none"],
       "default": "human",
-      "description": "Escalation policy when max_rounds reached without consensus"
+      "description": "Escalation policy when max_rounds reached without consensus. human: escalate to human via /ratchet:verdict. tiebreaker: auto-escalate to tiebreaker agent. both: tiebreaker first, then human review. none: no escalation — debate ends as unresolved REJECT after max_rounds (useful for CI/automated pipelines where human intervention is unavailable)."
     },
     "progress": {
       "type": "object",
@@ -188,7 +188,7 @@
     },
     "workflow_preset": {
       "type": "string",
-      "enum": ["tdd", "traditional", "review-only", "custom"],
+      "enum": ["tdd", "traditional", "review-only"],
       "description": "Workflow preset selecting phase subsets. tdd: plan→test→build→review→harden. traditional: plan→build→review→harden. review-only: review only."
     },
     "component": {

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -350,7 +350,7 @@ For each approved pair, write:
 ```yaml
 version: 2
 max_rounds: 3
-escalation: human  # human | tiebreaker | both
+escalation: human  # human | tiebreaker | both | none
 
 progress:
   adapter: none  # none | markdown | github-issues | linear | jira


### PR DESCRIPTION
Fixes #73

## Summary

- Removed undocumented `custom` from `workflow_preset` enum — no implementation existed, would silently pass validation then break at runtime
- Documented `escalation: none` behavior — debate ends as unresolved REJECT after max_rounds, no escalation triggered
- Updated init skill template comment to include `none` as valid escalation option

## Debates

| Pair | Phase | Verdict | Rounds |
|------|-------|---------|--------|
| schema-correctness | review | ACCEPT | 1 |
| skill-coherence | review | ACCEPT | 1 |

## Test plan

- [ ] Verify `jq empty schemas/workflow.schema.json` passes
- [ ] Verify `custom` is no longer accepted by schema validation
- [ ] Verify init skill documents all escalation modes