### PR TITLE
Harden agent definitions (debate-runner, analyst, tiebreaker, pairs)

### DIFF
--- a/.ratchet/pairs/skill-coherence/generative.md
+++ b/.ratchet/pairs/skill-coherence/generative.md
@@ -17,8 +17,7 @@ Ratchet skills are markdown files in `skills/*/SKILL.md` that define the behavio
 - `skills/debate/SKILL.md` — `/ratchet:debate` (view/continue debates)
 - `skills/status/SKILL.md` — `/ratchet:status` (progress dashboard)
 - `skills/score/SKILL.md` — `/ratchet:score` (quality metrics)
-- `skills/tighten/SKILL.md` — `/ratchet:tighten` (analyze signals and sharpen system)
-- `skills/tighten/SKILL.md` — `/ratchet:tighten` (improve agents based on performance)
+- `skills/tighten/SKILL.md` — `/ratchet:tighten` (analyze signals, improve agents, and sharpen system)
 - `skills/guard/SKILL.md` — `/ratchet:guard` (manage guards)
 - `skills/verdict/SKILL.md` — `/ratchet:verdict` (human tiebreaker for escalations)
 

--- a/agents/analyst.md
+++ b/agents/analyst.md
@@ -305,6 +305,24 @@ Before generating pair definitions, **discuss each pair individually** with the 
 
 The human's answers here directly shape the agent prompts — this is the most impactful part of init. Don't rush it.
 
+### Pair Approval Protocol
+
+After presenting each pair and incorporating the human's feedback, use `AskUserQuestion` to get an explicit decision:
+
+- Options: `"Approve this pair"`, `"Revise — I have more feedback"`, `"Drop this pair"`, `"Skip for now — decide later"`
+
+**Handle each response:**
+
+1. **Approve**: Generate the pair definition files immediately. Move to the next pair.
+2. **Revise**: Ask a follow-up question to understand what needs changing. Apply the feedback and re-present the revised pair. Allow up to **3 revision cycles** per pair — if the human is still unsatisfied after 3 iterations, offer:
+   - `"Drop this pair (Recommended — we can revisit later)"`, `"One more revision"`, `"Approve as-is with a note"`
+3. **Drop**: Do not generate pair definitions. Record the dropped pair and reason in a `dropped_pairs` list in `plan.yaml` under the milestone for traceability. Move to the next pair.
+4. **Skip**: Set the pair aside. After all other pairs are processed, re-present skipped pairs as a batch: `"You skipped N pairs. Review them now, or drop all?"` with options `"Review now"`, `"Drop all skipped pairs"`
+
+**Ordering**: If one pair depends on another (e.g., a build pair depends on a test pair's output), present the dependency first. If the human drops a dependency, warn: `"Pair X depends on the pair you just dropped. Drop X too, or keep it standalone?"`
+
+**Empty result**: If the human drops ALL proposed pairs, do not silently proceed with zero pairs. Use `AskUserQuestion`: `"All proposed pairs were dropped. Would you like to describe the quality dimensions you care about, or exit init?"` with options `"Describe what I want"`, `"Exit init"`
+
 ### Draw from Ecosystem Expertise
 
 When designing pairs, actively draw inspiration from ecosystem projects to enrich agent knowledge — don't just suggest these as tools to install, use their domain expertise as source material for pair design:

--- a/agents/debate-runner.md
+++ b/agents/debate-runner.md
@@ -172,6 +172,29 @@ Returned to caller:
 
 ## Execution Protocol
 
+### 0. Pre-flight Validation
+
+Before any debate work, validate the environment:
+
+**Worktree check** (if a `Worktree` path was provided in the task context):
+```bash
+if [ ! -d "<worktree-path>" ]; then
+  echo "ERROR: Worktree path does not exist: <worktree-path>" >&2
+  echo "The worktree may have been cleaned up or never created." >&2
+  echo "Re-run the orchestrator to create a fresh worktree." >&2
+  exit 1
+fi
+if [ ! -w "<worktree-path>" ]; then
+  echo "ERROR: Worktree path is not writable: <worktree-path>" >&2
+  echo "Check filesystem permissions." >&2
+  exit 1
+fi
+```
+
+If the worktree path does not exist or is not writable, **fail immediately** — do not create the debate directory, write meta.json, or spawn any agents. Return an error to the caller with the message above. No debate artifacts are created on pre-flight failure.
+
+**Pair definition check**: Verify both `.ratchet/pairs/<name>/generative.md` and `.ratchet/pairs/<name>/adversarial.md` exist (this is also covered in Error Handling below, but checking here prevents wasted work).
+
 ### 1. Create Debate Directory
 
 Generate debate ID: `<pair-name>-<timestamp>` (e.g., `api-contracts-20260314T100000`).
@@ -245,12 +268,12 @@ When constructing the `[If round > 1: ...]` sections in both generative and adve
 Prior round history (summarized):
 
 Round 1:
-- Generative: [2-3 sentence summary of what was proposed/changed]
-- Adversarial: [verdict] — [1-2 sentence summary of key concerns raised]
+- Generative: verdict=N/A | changed: file1.md, file2.md (+40/-12) | action: [imperative sentence: what was proposed or changed]
+- Adversarial: verdict=REJECT | evidence: [file:line refs or command output cited] | conditions: [numbered list of unresolved items] | key concern: [single sentence]
 
 Round 2:
-- Generative: [2-3 sentence summary of what was addressed/changed]
-- Adversarial: [verdict] — [1-2 sentence summary of remaining concerns]
+- Generative: verdict=N/A | changed: file1.md (+5/-3) | action: [what was addressed]
+- Adversarial: verdict=CONDITIONAL_ACCEPT | evidence: [refs] | conditions: [remaining items] | key concern: [single sentence]
 
 [...repeat for each prior round through N-2...]
 
@@ -259,7 +282,19 @@ Most recent round (full text):
 [full content of round-(N-1)-adversarial.md]
 ```
 
-The debate-runner generates these summaries by reading each prior round file and extracting: (1) the key changes or proposals from the generative output, (2) the verdict and primary concerns from the adversarial output. Keep summaries factual and specific — include file names, issue counts, and verdict keywords. Do not editorialize.
+**Summarization extraction rules** (the debate-runner generates these by reading each prior round file):
+
+For each **generative** round file, extract:
+1. **changed**: List every file path modified, with aggregate diffstat (lines added/removed). If the generative output includes a `changes_made` JSON field, use it directly.
+2. **action**: One imperative sentence describing the primary change (e.g., "Add worktree validation to step 1" not "The agent improved validation").
+
+For each **adversarial** round file, extract:
+1. **verdict**: The exact verdict keyword (ACCEPT, CONDITIONAL_ACCEPT, REJECT, TRIVIAL_ACCEPT, REGRESS).
+2. **evidence**: Up to 3 specific file:line references or command outputs the adversarial cited as evidence. If the adversarial JSON has a `findings` array, extract `file` and `line` from each entry.
+3. **conditions**: Numbered list of unresolved items (from `findings` with severity critical or major, or from CONDITIONAL_ACCEPT conditions).
+4. **key concern**: The single most important concern — extract from `verdict_reasoning` if present, otherwise from the highest-severity finding.
+
+Keep summaries factual. Use file names, line numbers, and verdict keywords. Do not editorialize or paraphrase subjective assessments.
 
 Spawn an Agent with `model` set to the generative model from the task context (e.g., `model: "opus"`). Use the phase-specific prompt:
 

--- a/agents/tiebreaker.md
+++ b/agents/tiebreaker.md
@@ -89,19 +89,22 @@ The code is not ready. Specific issues must be addressed:
 - Be specific about what "fixed" looks like
 
 #### MODIFY
-The code is **acceptable with conditions**. The adversarial raised both valid and invalid concerns, and you're rendering partial agreement:
-- List the specific changes required (subset of adversarial's concerns)
-- Explain which adversarial concerns are valid and which are not
-- **These changes are logged as conditions** — the code can proceed with the understanding that these items will be addressed in follow-up work
-- This verdict is effectively CONDITIONAL_ACCEPT with explicit dismissal of some adversarial concerns
+The tiebreaker's **partial dismissal** verdict. Use MODIFY when the adversarial raised a mix of valid and invalid concerns, and you — as the arbiter — need to separate them:
+- **Accept some findings**: List the specific changes required (the valid subset of adversarial concerns). These are logged as conditions.
+- **Dismiss others**: Explicitly list which adversarial concerns are NOT valid, with reasoning for each dismissal.
+- The code proceeds with the accepted conditions logged for follow-up.
+
+**MODIFY vs CONDITIONAL_ACCEPT — key distinction:**
+- **MODIFY** is a **tiebreaker-only** verdict rendered after max_rounds when both sides failed to agree. It involves the tiebreaker actively judging which adversarial findings have merit and which do not. The tiebreaker is the decision-maker — it partially sides with each party.
+- **CONDITIONAL_ACCEPT** is an **adversarial-only** verdict rendered during normal debate rounds. The adversarial voluntarily approves the generative's work subject to minor conditions being addressed in the next round. There is no dismissal of concerns — the adversarial owns all its conditions.
+
+In short: MODIFY = tiebreaker splits the adversarial's findings into "valid" and "dismissed". CONDITIONAL_ACCEPT = adversarial approves with strings attached, no third-party judgment involved.
 
 Use MODIFY when:
-- Some adversarial concerns are legitimate
-- But not all concerns warrant blocking the code
-- The code is fundamentally sound but has targeted improvements needed
-- You need to distinguish between "must fix" (MODIFY) vs "not issues" (dismissed)
-
-**Note**: Since you're invoked at max_rounds (no more debate rounds possible), MODIFY serves the same terminal function as CONDITIONAL_ACCEPT — it resolves the debate with logged conditions rather than requiring immediate fixes.
+- The adversarial raised both valid and invalid concerns (partial agreement)
+- You need to explicitly dismiss some findings as not warranting a block
+- The code is fundamentally sound but has targeted improvements needed from the valid subset
+- You are rendering a split decision — not a blanket approval or rejection
 
 ## How Your Verdict Is Used
 


### PR DESCRIPTION
Fixes #78

## Summary

- **debate-runner**: Added Section 0 pre-flight validation (worktree/pair checks), replaced vague summarization with structured extraction template
- **analyst**: Added pair approval protocol with approve/revise/drop/skip flow, 3-cycle limit
- **tiebreaker**: Clarified MODIFY (tiebreaker partial dismissal) vs CONDITIONAL_ACCEPT (adversarial conditional approval)
- **skill-coherence/generative.md**: Removed duplicate tighten/SKILL.md entry

## Debates

| Pair | Phase | Verdict | Rounds |
|------|-------|---------|--------|
| agent-effectiveness | review | ACCEPT | 2 |

R2 fixed: incorrect status reference in pre-flight validation.

## Test plan

- [ ] Verify debate-runner.md pre-flight section is well-structured
- [ ] Verify summarization template covers all required fields
- [ ] Verify no duplicate entries in pair definitions