### PR TITLE
Fix plan.schema.json field name and enum mismatches

### DIFF
--- a/schemas/plan.schema.json
+++ b/schemas/plan.schema.json
@@ -49,8 +49,7 @@
     },
     "discovery_source": {
       "type": "string",
-      "enum": ["manual", "watch", "tighten", "retro"],
-      "description": "How the discovery was created — manual (sidequest skill), watch (CI/PR monitor), tighten (retrospective), retro (retrospective analysis)"
+      "description": "How the discovery was created — free-form identifier. Conventions: 'manual' (sidequest skill), 'watch' (CI/PR monitor), 'tighten' (retrospective), 'retro' (retrospective analysis), or dynamic refs like 'pr-conflict-20', 'pr-ci-failure-42', 'debate-<id>', 'issue-<ref>'"
     },
     "epic": {
       "type": "object",
@@ -100,6 +99,10 @@
         "milestone_id": {
           "type": "integer",
           "description": "ID of the milestone currently being worked on"
+        },
+        "issue_ref": {
+          "type": ["string", "null"],
+          "description": "Issue ref currently being worked on within the milestone, or null"
         },
         "phase": {
           "$ref": "#/$defs/phase",


### PR DESCRIPTION
Fixes #84

## Summary

- Removed overly restrictive `source` enum from discovery schema — rejects valid dynamic values like `pr-conflict-20` and debate IDs
- Added optional `current_focus.issue_ref` field — already used by Go parser and sidequest skill

## Debates

| Pair | Phase | Verdict | Rounds |
|------|-------|---------|--------|
| schema-correctness | review | ACCEPT | 1 |

## Test plan

- [ ] Verify `jq empty schemas/plan.schema.json` passes
- [ ] Verify current plan.yaml structure is compatible with updated schema