### PR TITLE
Add check-jsonschema to flake.nix devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,10 +49,11 @@
             bash
             go
             golangci-lint
+            check-jsonschema
           ];
           shellHook = ''
             echo "Ratchet development environment loaded"
-            echo "Available tools: shellcheck, jq, yq, git, go, golangci-lint"
+            echo "Available tools: shellcheck, jq, yq, git, go, golangci-lint, check-jsonschema"
           '';
         };
       }


### PR DESCRIPTION
Fixes #88

## Summary
- Added `pkgs.check-jsonschema` to nix devShell buildInputs
- Enables real JSON Schema conformance validation: `check-jsonschema --schemafile schema.json <(yq -o=json config.yaml)`

## Debates
| Pair | Phase | Verdict | Rounds |
|------|-------|---------|--------|
| script-robustness | review | TRIVIAL_ACCEPT | 1 |

## Test plan
- [ ] `nix develop --command check-jsonschema --version` works
- [ ] `check-jsonschema --schemafile schemas/workflow.schema.json <(yq -o=json .ratchet/workflow.yaml)` passes