### PR TITLE
Remove phantom linear/jira adapters and audit all schema enums

### DIFF
--- a/.claude/ratchet-schemas/workflow.schema.json
+++ b/.claude/ratchet-schemas/workflow.schema.json
@@ -32,7 +32,7 @@
       "type": "string",
       "enum": ["human", "tiebreaker", "both", "none"],
       "default": "human",
-      "description": "Escalation policy when max_rounds reached without consensus"
+      "description": "Escalation policy when max_rounds reached without consensus. human: escalate to human via /ratchet:verdict. tiebreaker: auto-escalate to tiebreaker agent. both: tiebreaker first, then human review. none: no escalation — debate ends as unresolved REJECT after max_rounds (useful for CI/automated pipelines where human intervention is unavailable)."
     },
     "progress": {
       "type": "object",
@@ -40,7 +40,7 @@
       "properties": {
         "adapter": {
           "type": "string",
-          "enum": ["none", "markdown", "github-issues", "linear", "jira"],
+          "enum": ["none", "markdown", "github-issues"],
           "default": "none",
           "description": "Work tracking adapter — failures never block debates"
         },
@@ -188,7 +188,7 @@
     },
     "workflow_preset": {
       "type": "string",
-      "enum": ["tdd", "traditional", "review-only", "custom"],
+      "enum": ["tdd", "traditional", "review-only"],
       "description": "Workflow preset selecting phase subsets. tdd: plan→test→build→review→harden. traditional: plan→build→review→harden. review-only: review only."
     },
     "component": {

--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -40,7 +40,7 @@
       "properties": {
         "adapter": {
           "type": "string",
-          "enum": ["none", "markdown", "github-issues", "linear", "jira"],
+          "enum": ["none", "markdown", "github-issues"],
           "default": "none",
           "description": "Work tracking adapter — failures never block debates"
         },

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -252,7 +252,7 @@ Don't present all pairs at once for rubber-stamping. Walk through them — the u
   - `"Yes — post each round as a comment (per-round)"` — sets `publish_debates: per-round`
   - `"No — debates stay local only"` — sets `publish_debates: false`
 
-Skip this step entirely if the adapter selected in Step 6e is anything other than `github-issues` (i.e., `none`, `markdown`, `linear`, or `jira`).
+Skip this step entirely if the adapter selected in Step 6e is anything other than `github-issues` (i.e., `none` or `markdown`).
 
 **6g. Final review** — only after walking through each area, present the complete config for approval:
 - Question: "[full formatted config]. Everything look right?"
@@ -353,7 +353,7 @@ max_rounds: 3
 escalation: human  # human | tiebreaker | both | none
 
 progress:
-  adapter: none  # none | markdown | github-issues | linear | jira
+  adapter: none  # none | markdown | github-issues
   # publish_debates: false  # Only valid when adapter is github-issues.
   #   false (default) — debates stay local
   #   per-round       — post each debate round as a GitHub issue comment


### PR DESCRIPTION
Fixes #90

## Summary
- Removed unimplemented `linear` and `jira` from `progress.adapter` enum in workflow.schema.json
- Synced installed copy at `.claude/ratchet-schemas/workflow.schema.json`
- Removed phantom `custom` from `workflow_preset` enum in installed copy
- Updated init skill adapter references
- Full enum audit: no other phantom values found across all 3 schemas

## Debates
| Pair | Phase | Verdict | Rounds |
|------|-------|---------|--------|
| schema-correctness | review | ACCEPT | 2 |

R2 caught stale installed schema copy divergence.

## Test plan
- [ ] `jq empty schemas/workflow.schema.json` passes
- [ ] No references to `linear` or `jira` in skills or scripts