### PR TITLE
Upgrade schema-valid guard to real JSON Schema conformance validation

### DIFF
--- a/.ratchet/workflow.yaml
+++ b/.ratchet/workflow.yaml
@@ -79,6 +79,15 @@ guards:
         [ -f "$schema" ] || continue
         nix develop --command jq empty "$schema" || exit 1
       done
+      if [ -f ".ratchet/workflow.yaml" ] && [ -f "schemas/workflow.schema.json" ]; then
+        nix develop --command bash -c '
+          if command -v check-jsonschema >/dev/null 2>&1; then
+            yq -o json ".ratchet/workflow.yaml" | check-jsonschema --schemafile "schemas/workflow.schema.json" -
+          else
+            echo "Warning: check-jsonschema not available, skipping conformance validation" >&2
+          fi
+        ' || exit 1
+      fi
     phase: review
     blocking: true
     timing: post-debate

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
             bash
             go
             golangci-lint
+            check-jsonschema
           ];
           shellHook = ''
             echo "Ratchet development environment loaded"


### PR DESCRIPTION
Fixes #89

## Summary

- Upgraded `schema-valid` guard from `jq empty` syntax-only check to real JSON Schema conformance validation using `check-jsonschema`
- Both `yq` and `check-jsonschema` run inside a single `nix develop --command bash -c` for correct tool resolution
- File existence guards prevent confusing errors
- Graceful degradation when `check-jsonschema` is not available (transition period)
- Also adds `check-jsonschema` to flake.nix (duplicates PR 91 — whichever merges first wins)

Depends on: PR 91 (issue 88)

## Debates

| Pair | Phase | Verdict | Rounds |
|------|-------|---------|--------|
| script-robustness | review | CONDITIONAL_ACCEPT → ACCEPT | 1+1 |

First debate found shell correctness issue (yq outside nix develop). Re-debated with conditions addressed.

## Test plan

- [ ] `nix develop --command bash -c 'check-jsonschema --schemafile schemas/workflow.schema.json <(yq -o=json .ratchet/workflow.yaml)'` passes
- [ ] Guard degrades gracefully without check-jsonschema