### PR TITLE
Add --go compound flag for --unsupervised --auto-pr

### DIFF
--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -194,13 +194,14 @@ Phases within an issue are ordered and gated: phase N must complete before phase
 /ratchet:run --dry-run          # Preview what would run without executing anything
 /ratchet:run --unsupervised              # Run the full plan end-to-end without human intervention
 /ratchet:run --unsupervised --auto-pr    # Same, but auto-create PRs per issue
+/ratchet:run --go                        # Shorthand for --unsupervised --auto-pr
 ```
 
 ## Unsupervised Mode
 
 For unsupervised mode behavior, read `skills/run/unsupervised.md`.
 
-Covers: auto-selection rules for every `AskUserQuestion` step, self-continuation via the Agent tool at milestone boundaries, halt conditions (issue-level and milestone-level), and combining `--unsupervised` with `--auto-pr`, `--no-cache`, `--all-files`, and `--dry-run`.
+Covers: auto-selection rules for every `AskUserQuestion` step, self-continuation via the Agent tool at milestone boundaries, halt conditions (issue-level and milestone-level), and combining `--unsupervised` with `--auto-pr`, `--no-cache`, `--all-files`, and `--dry-run`. Note: `--go` is shorthand for `--unsupervised --auto-pr`.
 
 ## Prerequisites
 - `.ratchet/` must exist with valid config

--- a/skills/run/unsupervised.md
+++ b/skills/run/unsupervised.md
@@ -8,6 +8,8 @@
 
 When `--unsupervised` is set, the run loop executes the entire plan (all milestones, all phases) without human interaction. The principle is simple: **wherever an `AskUserQuestion` has a "(Recommended)" option, auto-select it.**
 
+> **`--go` flag**: `--go` is shorthand for `--unsupervised --auto-pr`. It is equivalent in every way — the same behavior, halt conditions, and self-continuation rules apply.
+
 ## Behavior
 
 - **Step 1a (workspace)**: If at workspace root with no workspace specified, **halt** — unsupervised mode requires an explicit workspace target (`/ratchet:run --unsupervised monitor`). Auto-selecting a workspace is too risky.
@@ -72,7 +74,10 @@ Unsupervised run [completed|paused]:
 
 ## Combining with Other Flags
 
+- `--go`: Shorthand for `--unsupervised --auto-pr` (identical behavior)
 - `--unsupervised --auto-pr`: Auto-create PRs at milestone boundaries (human pre-approves by passing this flag)
 - `--unsupervised --no-cache`: Force re-debate all files, unsupervised
 - `--unsupervised --all-files`: Run all pairs against all files, unsupervised
 - `--unsupervised --dry-run`: Dry-run takes precedence (preview only, no execution)
+- `--go --no-cache`: Combines `--go` with `--no-cache` (force re-debate, unsupervised, auto-PR)
+- `--go --all-files`: Combines `--go` with `--all-files` (all pairs, unsupervised, auto-PR)


### PR DESCRIPTION
## Summary

- Add `--go` as shorthand for `--unsupervised --auto-pr` in Usage section and unsupervised.md
- Documents compound combinations: `--go --no-cache`, `--go --all-files`

Fixes #96

## Debate Summary

| Pair | Phase | Rounds | Verdict | Decided By |
|------|-------|--------|---------|------------|
| skill-coherence | review | 1 | TRIVIAL_ACCEPT | consensus |