### PR TITLE
Add token cost estimates to --dry-run output

### DIFF
--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -1041,6 +1041,54 @@ orchestrator parses in Step 4c.
 
 If `--dry-run` is specified, produce a formatted preview and stop. No agents are spawned, no debates created, no files modified.
 
+#### Token Cost Estimation
+
+After building the dependency graph (Step 3), compute estimated tokens per issue using these formulas:
+
+**Base tokens by pipeline mode:**
+| Pipeline mode | Base tokens | Phases | Rationale |
+|---|---|---|---|
+| `solo` | 20k | (single pass) | Single generative pass, no adversarial |
+| `review` | 40k | review | Review-only debate (1 phase, gen + adv) |
+| `hotfix` | 60k | build, review | Fast-track fix (2 phases) |
+| `secure` | 60k | review, harden | Security hardening (2 phases) |
+| `standard` | 80k | plan, build, review, harden | Standard pipeline (4 phases) |
+| `full` | 160k | plan, test, build, review, harden | Full pipeline (5 phases) |
+
+**Scaling factors:**
+- **Pairs**: Multiply base by the number of pairs assigned to the issue. Each pair runs its own debate/execution.
+- **Guards**: Add 2k per guard (both pre-execution and post-execution) assigned to the issue's phases. Guards invoke external commands and produce output that consumes context.
+- **Max rounds** (debate mode only): The base already accounts for typical round counts. For `max_rounds > 3`, scale the debate portion by `max_rounds / 3`.
+
+**Formula:**
+```
+issue_tokens = (base_tokens × pair_count × round_scale) + (2000 × guard_count)
+
+where:
+  base_tokens  = mode lookup from table above
+  pair_count   = number of pairs assigned to the issue
+  round_scale  = max(1, max_rounds / 3) for debate strategies, 1 for solo
+  guard_count  = number of guards matching the issue's component and phases
+```
+
+**Cost estimation** uses current API rates (update these when rates change):
+- Opus input: $15 / 1M tokens, output: $75 / 1M tokens (assume 30% input, 70% output)
+- Sonnet input: $3 / 1M tokens, output: $15 / 1M tokens (assume 30% input, 70% output)
+- Debate mode uses both opus (generative) and sonnet (adversarial) — estimate 60% opus, 40% sonnet by token volume
+- Solo mode uses opus only
+
+```
+# Blended rate per 1k tokens (debate mode):
+#   opus:   0.30 × $0.015 + 0.70 × $0.075 = $0.057/1k tokens
+#   sonnet: 0.30 × $0.003 + 0.70 × $0.015 = $0.0114/1k tokens
+#   blended = 0.60 × $0.057 + 0.40 × $0.0114 = $0.0388/1k tokens
+#
+# Solo mode (opus only):
+#   $0.057/1k tokens
+```
+
+#### Dry-Run Output Format
+
 ```
 Dry-Run Preview
 ═══════════════
@@ -1055,7 +1103,6 @@ Issues ([N] total, [N] ready to run in parallel):
     Pairs: [pair-name], [pair-name]
     Pre-execution guards: [guard-name] (blocking)
     Post-execution guards: [guard-name] (advisory)
-    Est. tokens: ~[N]k per phase (generative + adversarial × max_rounds)
 
   [ref]: [title]  (solo)
     Strategy: solo
@@ -1063,7 +1110,6 @@ Issues ([N] total, [N] ready to run in parallel):
     Pairs: [pair-name]
     Post-execution guards: [guard-name] (blocking)
     Promote on guard failure: [yes|no]
-    Est. tokens: ~[N]k per phase (generative only, no adversarial)
 
   [ref]: [title]  (depends on [dep-ref])
     Phase: pending — waiting for dependency
@@ -1071,16 +1117,31 @@ Issues ([N] total, [N] ready to run in parallel):
 
 Phase flow per issue: [phase1] → [phase2] → ... → [phaseN]
 
-Token estimates:
-  Debate issues: ~[N]k total (generative + adversarial × rounds × phases)
-  Solo issues:   ~[N]k total (generative × phases, ~40-60% of debate cost)
-  Combined:      ~[N]k estimated for this milestone
+Token & Cost Estimates
+──────────────────────
+  Issue       Mode       Pairs  Guards  Est. Tokens   Est. Cost
+  ─────       ────       ─────  ──────  ───────────   ─────────
+  [ref]       standard   2      3       ~166k         ~$6.44
+  [ref]       solo       1      2       ~24k          ~$1.37
+  [ref]       review     1      1       ~42k          ~$1.63
+  ─────       ────       ─────  ──────  ───────────   ─────────
+  Total                                 ~232k         ~$9.44
 ```
 
-**Token estimation heuristic**: Solo mode issues use roughly 40-60% of the tokens of debate mode issues for the same phase, because they skip adversarial review rounds entirely. The estimate scales with `max_rounds` for debate mode (each round incurs both generative and adversarial tokens) but is fixed at one pass for solo mode.
+**In `--unsupervised` mode**: Log the token and cost estimates to stdout but do not block execution. The estimates are informational — they help operators audit spend after the fact. Do not present the `AskUserQuestion` confirmation (unsupervised auto-selects "Run for real").
 
-Then use `AskUserQuestion`:
-- Options: `"Run for real (Recommended)"`, `"Done for now"`
+**In supervised mode**: Include the cost table in the `AskUserQuestion` confirmation:
+
+Question text:
+```
+Dry-run complete. Estimated cost: ~$[total] ([total_tokens]k tokens).
+
+[cost table from above]
+
+Proceed?
+```
+
+Options: `"Run for real (Recommended)"`, `"Done for now"`
 
 ---
 

--- a/skills/run/unsupervised.md
+++ b/skills/run/unsupervised.md
@@ -15,7 +15,7 @@ When `--unsupervised` is set, the run loop executes the entire plan (all milesto
 - **Step 1a (workspace)**: If at workspace root with no workspace specified, **halt** — unsupervised mode requires an explicit workspace target (`/ratchet:run --unsupervised monitor`). Auto-selecting a workspace is too risky.
 - **Step 2 (focus)**: Auto-select "Run all ready issues sequentially" for the current milestone. When a milestone completes, auto-advance to the next. In DAG mode, auto-launch all ready milestones in parallel.
 - **Step 4 (issue pipelines)**: Execute all ready issues sequentially inline. Each issue pipeline runs in an isolated worktree, spawning only debate-runner agents.
-- **Step 5-dry (dry-run)**: Incompatible with `--unsupervised` — if both are set, ignore `--dry-run`.
+- **Step 5-dry (dry-run)**: Dry-run takes precedence — produce the preview (including token and cost estimates), log the estimates to stdout, and stop. No agents are spawned. The `AskUserQuestion` confirmation is skipped (estimates are informational only).
 - **Step 5c (pre-debate guards)**: If a blocking pre-debate guard fails → auto-select "Fix and re-run". The generative agent attempts to fix the issue. If the fix fails after 2 attempts, that issue **halts** (other issues continue).
 - **Step 6 (static analysis)**: Auto-select "Fix these before running". Same 2-attempt retry, then halt.
 - **Step 5e (debates)**: Run normally. Debates are autonomous by nature. If debate-runner cannot be spawned (tool unavailable), the issue **halts** with status `blocked` — quality gates cannot be compromised.


### PR DESCRIPTION
## Summary
- Concrete token estimation formula with base-tokens-by-mode table (6 presets)
- Scaling factors: pair count, guard count, max_rounds
- Cost estimates using blended opus/sonnet rates
- Token & Cost Estimates table in dry-run output
- Fixed dry-run vs unsupervised precedence contradiction

Fixes #116

## Debate Summary
| Pair | Phase | Rounds | Verdict | Decided By |
|------|-------|--------|---------|------------|
| skill-coherence | review | 1 | ACCEPT | consensus |