### PR TITLE
Tighten: activate self-tuning infrastructure and fix stale state

### DIFF
--- a/.ratchet/pairs/agent-effectiveness/generative.md
+++ b/.ratchet/pairs/agent-effectiveness/generative.md
@@ -112,6 +112,16 @@ Before writing your round output, explicitly declare:
 This prevents the adversarial from needing to independently verify whether ALL identified fixes were applied,
 which was a cause of multi-round debates.
 
+## Debate Artifact Preservation
+
+Verify that debate artifacts survive the full lifecycle from creation through archival:
+- [ ] Debate-runner creates `.ratchet/debates/{id}/meta.json` and round files
+- [ ] Archive operations preserve ALL debate directories referenced in plan.yaml
+- [ ] Run: `for id in $(yq -r '.. | .debates[]? // empty' .ratchet/plan.yaml 2>/dev/null); do [ -d ".ratchet/debates/$id" ] || find .ratchet/archive -name "$id" -type d 2>/dev/null | grep -q . || echo "MISSING: $id"; done`
+- [ ] No debate IDs in plan.yaml should point to non-existent artifact directories
+
+This was identified as a structural gap: all 11 debate artifacts from the "Lightweight Mode" epic were lost, leaving the system unable to learn from its own history.
+
 ## Common Issues to Fix
 
 1. **Outdated tool lists** — agent allowed tools that don't exist or forbidden tools it needs

--- a/.ratchet/pairs/script-robustness/adversarial.md
+++ b/.ratchet/pairs/script-robustness/adversarial.md
@@ -91,6 +91,10 @@ The debate-runner appends GUILTY UNTIL PROVEN INNOCENT and WORKTREE ISOLATION co
 **Examples must be runnable:**
 - [ ] Usage examples must be concrete and runnable, not abstract
 
+**Parallel guard contention:**
+- [ ] When reviewing guard execution scripts, verify flock/locking behavior under parallel execution. Test concurrent guard runs do not corrupt shared state. Run: `grep -n 'flock' scripts/**/*.sh`
+      Source: script-robustness-20260331T071459 review suggestion
+
 ## Baseline Validation State (Injected at Spawn Time)
 
 See debate-runner agent definition for baseline injection mechanism and usage rules.

--- a/.ratchet/pairs/skill-coherence/adversarial.md
+++ b/.ratchet/pairs/skill-coherence/adversarial.md
@@ -58,6 +58,8 @@ The debate-runner appends GUILTY UNTIL PROVEN INNOCENT and WORKTREE ISOLATION co
 - [ ] **Data flow completeness**: For input-gathering skills, verify every AskUserQuestion maps to a stored field, no orphan fields. Run: `grep -c 'AskUserQuestion' skills/*/SKILL.md`
 - [ ] **Canonical schema reference**: When unifying a data structure across skills, verify a canonical field list was created FIRST
 - [ ] **Concrete examples required**: Any instruction involving file format manipulation, tool usage, or conditional logic must show concrete examples
+- [ ] **Stale field name sweep after schema renames**: When a schema field is renamed or restructured, grep all SKILL.md files and agent definitions for the old field name in prose, examples, and inline YAML/JSON snippets. Run: `grep -rn 'old_field_name' skills/*/SKILL.md agents/*.md`
+      Source: skill-coherence-20260331T071924 conditional accept (stale field names in explanatory text after schema change)
 
 ## Baseline Validation State (Injected at Spawn Time)
 

--- a/.ratchet/workflow.yaml
+++ b/.ratchet/workflow.yaml
@@ -20,18 +20,23 @@ components:
   - name: skills
     scope: "skills/*/SKILL.md"
     pipeline: review
+    strategy: debate
 
   - name: agents
     scope: "agents/*.md"
     pipeline: review
+    strategy: debate
 
   - name: scripts
     scope: "scripts/**/*.sh,install.sh"
     pipeline: review
+    strategy: debate
 
   - name: schemas
     scope: "schemas/*.json"
     pipeline: review
+    strategy: solo
+    promote_on_guard_failure: true
 
 pairs:
   - name: skill-coherence
@@ -63,14 +68,14 @@ guards:
     command: "bash scripts/check-generated-files.sh"
     phase: review
     blocking: true
-    timing: pre-debate
+    timing: pre-execution
     components: [skills, agents, scripts, schemas]
 
   - name: shellcheck
     command: "nix develop --command shellcheck scripts/**/*.sh install.sh"
     phase: review
     blocking: true
-    timing: pre-debate
+    timing: pre-execution
     components: [scripts]
 
   - name: schema-valid
@@ -90,7 +95,7 @@ guards:
       fi
     phase: review
     blocking: true
-    timing: post-debate
+    timing: post-execution
     components: [schemas]
 
   - name: meta-json-valid
@@ -111,5 +116,44 @@ guards:
       exit $failed
     phase: review
     blocking: false
-    timing: post-debate
+    timing: post-execution
+    components: [skills, agents, scripts, schemas]
+
+  - name: debate-artifacts-complete
+    type: rationalization-check
+    phase: review
+    blocking: false
+    timing: post-execution
+    components: [skills, agents, scripts, schemas]
+    checks:
+      - assert: "All referenced debate IDs have artifact directories"
+        command: |
+          missing=0
+          for id in $(yq -r '.. | .debates[]? // empty' .ratchet/plan.yaml 2>/dev/null); do
+            [ -z "$id" ] && continue
+            if [ ! -d ".ratchet/debates/$id" ] && ! find .ratchet/archive -name "$id" -type d 2>/dev/null | grep -q .; then
+              echo "MISSING debate artifacts: $id" >&2; missing=1
+            fi
+          done
+          exit $missing
+      - assert: "Active debates have resolved timestamps"
+        command: |
+          for f in .ratchet/debates/*/meta.json; do
+            [ -f "$f" ] || continue
+            resolved=$(jq -r '.resolved // "null"' "$f")
+            [ "$resolved" != "null" ] || { echo "UNRESOLVED: $f" >&2; exit 1; }
+          done
+
+  - name: plan-valid
+    command: |
+      if [ -f ".ratchet/plan.yaml" ] && [ -f "schemas/plan.schema.json" ]; then
+        if command -v check-jsonschema >/dev/null 2>&1; then
+          yq -o json ".ratchet/plan.yaml" | check-jsonschema --schemafile "schemas/plan.schema.json" -
+        else
+          echo "Warning: check-jsonschema not available, skipping plan validation" >&2
+        fi
+      fi
+    phase: review
+    blocking: false
+    timing: post-execution
     components: [skills, agents, scripts, schemas]


### PR DESCRIPTION
## Summary
- Fixed stale `current_focus` pointing to completed milestone 3
- Added explicit `strategy` field to all components (schemas to solo mode with guard promotion)
- Deployed first `rationalization-check` guard (`debate-artifacts-complete`) — validates debate artifact existence
- Added `plan-valid` guard for plan.yaml schema validation
- Renamed guard timing values from deprecated `pre-debate`/`post-debate` to `pre-execution`/`post-execution`
- Added settled law entries: stale-field-sweep (skill-coherence), parallel contention (script-robustness)
- Added debate artifact preservation checks to agent-effectiveness generative prompt

## Context
All 10 findings verified by adversarial fact-checker (1 upgraded — all 11 debate artifacts missing, not 9).
The "Lightweight Mode" epic built self-tuning infrastructure but never activated it on itself.

## Test plan
- [ ] Verify `yq -o json .ratchet/workflow.yaml | jq empty` succeeds
- [ ] Verify `grep -c "pre-execution\|post-execution" .ratchet/workflow.yaml` returns 4
- [ ] Verify `grep -c "strategy:" .ratchet/workflow.yaml` returns 4
- [ ] Verify `grep -c "rationalization-check" .ratchet/workflow.yaml` returns 1
- [ ] Verify settled law sections updated in pair adversarials