### PR TITLE
Wire stale-base guard into schema, workflow, and templates

### DIFF
--- a/.ratchet/workflow.yaml
+++ b/.ratchet/workflow.yaml
@@ -73,6 +73,13 @@ guards:
     timing: pre-debate
     components: [scripts]
 
+  - name: stale-base
+    command: "bash scripts/check-stale-base.sh --issue \"$RATCHET_ISSUE_REF\" --plan .ratchet/plan.yaml --worktree \"$RATCHET_WORKTREE\""
+    phase: review
+    blocking: true
+    timing: pre-execution
+    components: [skills, agents, scripts, schemas]
+
   - name: schema-valid
     command: |
       for schema in schemas/*.schema.json; do

--- a/agents/analyst.md
+++ b/agents/analyst.md
@@ -245,6 +245,13 @@ pairs:
     enabled: true
 
 guards: []
+  # Uncomment to enable stale-base detection (catches missing dependency changes):
+  # - name: stale-base
+  #   command: "bash scripts/check-stale-base.sh --issue \"$RATCHET_ISSUE_REF\" --plan .ratchet/plan.yaml --worktree \"$RATCHET_WORKTREE\""
+  #   phase: review
+  #   blocking: true
+  #   timing: pre-execution
+  #   components: []  # all components
 ```
 
 Read config from `workflow.yaml` (v2 format required).

--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -117,7 +117,7 @@
       "items": {
         "$ref": "#/$defs/guard"
       },
-      "description": "Deterministic checks at phase boundaries"
+      "description": "Deterministic checks at phase boundaries (e.g., stale-base detection, linting, test suites)"
     },
     "resources": {
       "type": "array",
@@ -323,7 +323,7 @@
         },
         "command": {
           "type": "string",
-          "description": "Shell command to execute — exit 0 = pass, non-zero = fail. Used by standard guards."
+          "description": "Shell command to execute — exit 0 = pass, non-zero = fail. Used by standard guards (e.g., scripts/check-stale-base.sh)."
         },
         "checks": {
           "type": "array",
@@ -348,7 +348,7 @@
             { "enum": ["pre-debate", "post-debate"], "description": "Deprecated — use pre-execution/post-execution instead" }
           ],
           "default": "post-execution",
-          "description": "When this guard runs — pre-execution (before debates start) or post-execution (after debates complete, default). Legacy values pre-debate/post-debate are accepted for backward compatibility."
+          "description": "When this guard runs — pre-execution (before debates start, e.g., stale-base detection) or post-execution (after debates complete, default). Legacy values pre-debate/post-debate are accepted for backward compatibility."
         },
         "components": {
           "type": "array",

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -235,6 +235,17 @@ Don't present all pairs at once for rubber-stamping. Walk through them — the u
     components: []  # all components
   ```
   Present this as: "I'll include the built-in generated-files guard — it prevents committing build artifacts like [stack-specific examples based on project.yaml, e.g., '*_templ.go files' for Go, 'node_modules/' for Node]."
+- **Suggest stale-base guard for projects with issue dependencies**: If the plan uses `depends_on` between issues, suggest the stale-base guard. Present it as a commented-out example that users can enable:
+  ```yaml
+  # Uncomment to enable stale-base detection (catches missing dependency changes):
+  # - name: stale-base
+  #   command: "bash scripts/check-stale-base.sh --issue \"$RATCHET_ISSUE_REF\" --plan .ratchet/plan.yaml --worktree \"$RATCHET_WORKTREE\""
+  #   phase: review
+  #   blocking: true
+  #   timing: pre-execution
+  #   components: []  # all components
+  ```
+  The `$RATCHET_ISSUE_REF` and `$RATCHET_WORKTREE` variables are substituted by the run skill at invocation time with the current issue reference and worktree path. This guard runs before debates start to catch stale-base conditions early — preventing wasted debate cycles on a branch missing dependency changes.
 - **Start from CI**: For each quality gate command discovered in CI/CD pipelines during the codebase scan (Step 2), propose a matching guard. The goal is that every check CI runs should have a corresponding Ratchet guard so debates never produce code that will fail the pipeline. Present these as: "I found these checks in your CI pipeline — I'll mirror them as guards:"
   - Map CI steps to guard properties: lint/format commands → `timing: pre-debate`, `phase: build`, `blocking: true`; test commands → `timing: post-debate`, `phase: build`, `blocking: true`; security scans → `timing: post-debate`, `phase: harden`, `blocking: true`; type checks → `timing: pre-debate`, `phase: build`, `blocking: true`
 - **Then suggest additions**: Based on the stack, suggest guards for checks that CI *doesn't* run but should (e.g., "Your CI doesn't run a security scanner — want to add one as an advisory guard?")


### PR DESCRIPTION
## Summary

- Adds stale-base detection examples to guard description strings in schemas/workflow.schema.json
- Adds `stale-base` guard entry to .ratchet/workflow.yaml (pre-execution, blocking, all components)
- Adds commented-out stale-base guard example in analyst.md workflow config template
- Adds conditional guidance in init SKILL.md to suggest stale-base guard for projects using `depends_on`

Fixes #139

## Test plan

- [ ] Verify schemas/workflow.schema.json descriptions mention stale-base detection
- [ ] Verify .ratchet/workflow.yaml has stale-base guard entry with correct timing and blocking settings
- [ ] Verify agents/analyst.md has commented-out stale-base guard example
- [ ] Verify skills/init/SKILL.md suggests stale-base guard for dependency-using projects