### PR TITLE
Extend watch skill to detect PR review comments

### DIFF
--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ratchet:watch
-description: Watch active PRs for merge conflicts and CI failures, auto-create sidequests
+description: Watch active PRs for merge conflicts, CI failures, and review comments
 ---
 
 # /ratchet:watch — PR Monitor
 
-Watch active Ratchet PRs for merge conflicts and CI failures. When problems are detected, automatically creates discoveries in plan.yaml so they surface in `/ratchet:run` and `/ratchet:status`.
+Watch active Ratchet PRs for merge conflicts, CI failures, and review comments. When problems are detected, automatically creates discoveries in plan.yaml so they surface in `/ratchet:run` and `/ratchet:status`. When actionable review comments are detected, spawns response agents to address feedback directly on the PR branch.
 
 Uses Claude Code's `/loop` feature to poll every 10 minutes.
 
@@ -13,7 +13,8 @@ Uses Claude Code's `/loop` feature to poll every 10 minutes.
 
 ## Usage
 ```
-/ratchet:watch              # Start watching PRs
+/ratchet:watch              # Start watching PRs (includes review comment detection)
+/ratchet:watch --no-respond # Watch but don't auto-spawn response agents for reviews
 /ratchet:watch --stop       # Stop watching
 ```
 
@@ -39,11 +40,23 @@ If no PRs exist in plan.yaml, inform the user:
 
 2. **Resolve workspace** (same logic as `/ratchet:run` Step 1a)
 3. **Verify PRs exist** — scan plan.yaml for issues with non-null `pr` fields
-4. **Start loop**:
+4. **Initialize watch state** — load or create `.ratchet/watch-state.json`:
+   ```bash
+   if [ ! -f .ratchet/watch-state.json ]; then
+     echo '{"seen_comment_ids": [], "seen_review_ids": []}' > .ratchet/watch-state.json
+   fi
    ```
-   /loop 10m check Ratchet PRs for conflicts and CI failures
+   The watch state file tracks which review comments and reviews have already been processed to avoid re-processing on subsequent poll cycles.
+
+5. **Parse flags**:
+   - `--no-respond`: Disable auto-spawning response agents for review comments. When set, actionable comments are logged as feedback entries but no agent is spawned. Default behavior (without this flag) is to auto-respond when the `github-issues` progress adapter is configured in `workflow.yaml`.
+   - `--stop`: Cancel the loop and exit.
+
+6. **Start loop**:
    ```
-5. **Confirm**: "Watching [N] PRs. Checking every 10 minutes. Use /ratchet:watch --stop to end."
+   /loop 10m check Ratchet PRs for conflicts, CI failures, and review comments
+   ```
+7. **Confirm**: "Watching [N] PRs. Checking every 10 minutes. Use /ratchet:watch --stop to end."
 
 ### Each Poll Cycle
 
@@ -98,14 +111,122 @@ ci_status=$(gh pr view "$pr_num" --json statusCheckRollup -q '.statusCheckRollup
   ```
 - Report: "CI failure detected: PR #[N] ([failed checks]) — discovery created"
 
-**All clear**: No output (silent when nothing is wrong).
+**Review comments detected** — fetch and classify new review activity:
+
+```bash
+# Get the repo owner/name from gh
+repo_nwo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+# Fetch PR review comments (inline code comments)
+comments_json=$(gh api "repos/${repo_nwo}/pulls/${pr_num}/comments" \
+  --jq '.[] | {id: .id, user: .user.login, body: .body, path: .path, created_at: .created_at, in_reply_to_id: .in_reply_to_id}' 2>/dev/null) || true
+
+# Fetch PR reviews (top-level review verdicts: APPROVED, CHANGES_REQUESTED, COMMENTED)
+reviews_json=$(gh pr view "$pr_num" --json reviews \
+  -q '.reviews[] | {id: .id, author: .author.login, state: .state, body: .body, submittedAt: .submittedAt}' 2>/dev/null) || true
+```
+
+**Filter already-seen comments** — compare against `.ratchet/watch-state.json`:
+```bash
+seen_comment_ids=$(jq -r '.seen_comment_ids[]' .ratchet/watch-state.json 2>/dev/null)
+seen_review_ids=$(jq -r '.seen_review_ids[]' .ratchet/watch-state.json 2>/dev/null)
+```
+
+Skip any comment or review whose ID appears in the seen lists. For each **new** comment or review:
+
+**Classify as actionable or informational:**
+
+| Category | Signal | Action |
+|---|---|---|
+| **Actionable: Requested change** | Review state `CHANGES_REQUESTED`, or comment contains specific code suggestion, fix request, or "please change/update/fix" | Create feedback entry |
+| **Actionable: Question** | Comment ends with `?` or contains "why", "how", "could you explain" | Create feedback entry |
+| **Actionable: Code suggestion** | Comment contains a fenced code block with suggested replacement | Create feedback entry |
+| **Informational: Approval** | Review state `APPROVED` | Log only, no action |
+| **Informational: Acknowledgment** | Comment body matches LGTM, "looks good", "nice", thumbs up | Log only, no action |
+
+**Filter bot comments** — exclude comments from the authenticated `gh` user to avoid self-referential feedback loops:
+```bash
+bot_user=$(gh api user --jq .login 2>/dev/null) || bot_user=""
+# Skip any comment where .user == "$bot_user"
+# Skip any review where .author == "$bot_user"
+```
+If `bot_user` cannot be determined (API failure), proceed without filtering but log a warning:
+```
+Warning: Could not determine authenticated GitHub user — bot comment filtering disabled
+```
+
+**For each actionable comment** (after bot filtering), create a structured feedback entry in plan.yaml:
+```bash
+yq eval -i ".epic.discoveries += [{
+  \"ref\": \"feedback-review-${pr_num}-$(date +%s)\",
+  \"title\": \"Review feedback on PR #${pr_num}: $(echo "$comment_body" | head -c 60)\",
+  \"description\": \"$comment_body\",
+  \"source\": \"pr-review-${pr_num}\",
+  \"created_at\": \"$(date -Iseconds)\",
+  \"severity\": \"major\",
+  \"status\": \"pending\",
+  \"retro_type\": \"review-feedback\",
+  \"issue_ref\": \"$issue_ref\",
+  \"review_comment_id\": $comment_id,
+  \"review_file_path\": \"$comment_path\",
+  \"review_author\": \"$comment_author\",
+  \"review_category\": \"$category\"
+}]" .ratchet/plan.yaml
+```
+
+The feedback discovery uses flat top-level fields prefixed with `review_` to remain consistent with the existing discovery schema pattern (all flat key-value pairs, no nested objects). Fields:
+- `review_comment_id`: The GitHub comment ID for deduplication and linking
+- `review_file_path`: The file path the comment is attached to (null for top-level reviews)
+- `review_author`: The GitHub username who left the comment
+- `review_category`: One of `requested_change`, `question`, `code_suggestion`
+
+- Report: "Review feedback detected: PR #[N] — [count] actionable comment(s) from [author(s)]"
+
+**Update watch state** — append all newly processed IDs (both actionable and informational) to `.ratchet/watch-state.json`:
+```bash
+jq --argjson new_comments "$new_comment_ids_json" \
+   --argjson new_reviews "$new_review_ids_json" \
+   '.seen_comment_ids += $new_comments | .seen_review_ids += $new_reviews' \
+   .ratchet/watch-state.json > .ratchet/watch-state.json.tmp \
+   && mv .ratchet/watch-state.json.tmp .ratchet/watch-state.json
+```
+
+**Auto-respond behavior** (when `--no-respond` is NOT set and `github-issues` adapter is configured):
+- For each actionable feedback entry, the watcher notes the feedback for the response agent (see m4-response-agent). The response agent is a separate concern — this issue only detects and classifies review comments.
+- When `--no-respond` IS set: feedback entries are created in plan.yaml but no response agent is spawned. The feedback surfaces in `/ratchet:status` for manual handling.
+
+**All clear**: No output (silent when nothing is wrong — no conflicts, no CI failures, no new review comments).
 
 ### Stopping
 
 `/ratchet:watch --stop` — cancel the loop. No cleanup needed beyond stopping the loop itself.
 
+## Watch State File
+
+The watcher maintains `.ratchet/watch-state.json` to track which review comments and reviews have been processed. Structure:
+
+```json
+{
+  "seen_comment_ids": [12345, 12346],
+  "seen_review_ids": [67890]
+}
+```
+
+This file is created automatically on first run if it does not exist. It persists across poll cycles within a session and across sessions (since it lives on disk). To force re-processing of all comments (e.g., after a reset), delete this file:
+
+```bash
+rm .ratchet/watch-state.json
+```
+
+**Error handling**: If `.ratchet/watch-state.json` exists but contains invalid JSON, the watcher recreates it with empty arrays and logs a warning:
+```
+Warning: .ratchet/watch-state.json was malformed — reset to empty state
+```
+
 ## Limitations
 
-- **Session-scoped**: stops when you close Claude Code
-- **Requires `gh` auth**: uses GitHub CLI for PR status
+- **Session-scoped**: the loop stops when you close Claude Code
+- **Requires `gh` auth**: uses GitHub CLI for PR status and review comment fetching
 - **Only watches PRs in plan.yaml**: PRs created outside Ratchet are not monitored
+- **Comment classification is heuristic**: the actionable vs informational classification uses pattern matching — edge cases may misclassify (e.g., a rhetorical question classified as actionable). When in doubt, comments are classified as actionable to avoid missing feedback.
+- **Bot comments are skipped**: comments from the authenticated `gh` user (typically the bot running Ratchet) are excluded from processing to avoid self-referential feedback loops


### PR DESCRIPTION
Fixes #131

## Summary
- Adds review comment detection as third detection category in `/ratchet:watch`
- Tracks seen comment IDs in `.ratchet/watch-state.json` to avoid re-processing
- Classifies comments as actionable (requested changes, code suggestions) vs informational (approvals)
- Filters bot-user comments before classification
- Adds `--respond` flag to control auto-spawning of response agents

## Debate
| Pair | Verdict | Rounds |
|------|---------|--------|
| skill-coherence | ACCEPT | 2 (CONDITIONAL_ACCEPT R1, ACCEPT R2) |

Conditions resolved: flattened review_meta into top-level fields, added bot-user filtering

## Test plan
- [ ] Verify watch skill detects new review comments on open PRs
- [ ] Verify seen comment IDs are tracked and not re-processed
- [ ] Verify bot comments are filtered