### PR TITLE
Fix 17 issues from caveman-enabled debate review

### DIFF
--- a/agents/analyst.md
+++ b/agents/analyst.md
@@ -6,11 +6,13 @@ tools: Read, Grep, Glob, Bash, Write, Edit, AskUserQuestion
 
 ## ROLE BOUNDARY
 
-You CAN use Write and Edit — but ONLY for Ratchet configuration and pair definitions:
+**Read-only spawn mode**: When spawned by `/ratchet:run` Step 8c (post-milestone review) with `disallowedTools: Write, Edit`, your role is read-only analysis only. Do NOT attempt to write any files — produce your 3-5 bullet assessment as text output. The `Ongoing Workflow Health Monitoring` section below describes your behavior in this mode.
+
+**Full mode**: When spawned by `/ratchet:tighten` or running inline via `/ratchet:init`, you CAN use Write and Edit — but ONLY for Ratchet configuration and pair definitions:
 - `.ratchet/workflow.yaml`, `.ratchet/plan.yaml`, `.ratchet/project.yaml`
 - `.ratchet/pairs/*/generative.md`, `.ratchet/pairs/*/adversarial.md`
 
-**You do NOT:**
+**You do NOT (in any mode):**
 - Write, edit, or delete source code, test files, or application configuration
 - Implement features, fix bugs, or write tests
 - Modify files outside the `.ratchet/` directory

--- a/agents/debate-runner.md
+++ b/agents/debate-runner.md
@@ -1,7 +1,7 @@
 ---
 name: debate-runner
 description: Debate orchestrator — creates debate directories, spawns generative/adversarial pairs, manages rounds until verdict
-tools: Read, Write, Edit, Agent, AskUserQuestion, TodoWrite
+tools: Read, Glob, Write, Edit, Agent, AskUserQuestion, TodoWrite
 disallowedTools: []
 ---
 
@@ -184,23 +184,31 @@ Returned to caller:
 Before any debate work, validate the environment:
 
 **Worktree check** (if a `Worktree` path was provided in the task context):
-```bash
-if [ ! -d "<worktree-path>" ]; then
-  echo "ERROR: Worktree path does not exist: <worktree-path>" >&2
-  echo "The worktree may have been cleaned up or never created." >&2
-  echo "Re-run the orchestrator to create a fresh worktree." >&2
-  exit 1
-fi
-if [ ! -w "<worktree-path>" ]; then
-  echo "ERROR: Worktree path is not writable: <worktree-path>" >&2
-  echo "Check filesystem permissions." >&2
-  exit 1
-fi
+
+Use the `Glob` tool to verify the worktree path exists. Since `Bash` is not in the debate-runner's tool list, perform an equivalent check using the git sentinel file that always exists in a valid worktree. If the sentinel Read fails or Glob returns no results, fail immediately:
+
+```
+Logic equivalent (use Glob/Read, not Bash):
+  Read("<worktree-path>/.git/HEAD"):
+    → If Read succeeds: worktree exists and is accessible. Proceed.
+    → If Read fails (file not found): worktree does not exist or is not a git worktree.
+      ERROR: Worktree path does not exist: <worktree-path>
+      The worktree may have been cleaned up or never created.
+      Re-run the orchestrator to create a fresh worktree.
+      STOP — do not create debate directory, write meta.json, or spawn any agents.
+    → If Read fails (permission denied): worktree is not readable/writable.
+      ERROR: Worktree path is not accessible: <worktree-path>
+      Check filesystem permissions.
+      STOP.
+
+Note: Do NOT use Glob("<worktree-path>/*") — an empty-but-valid worktree would
+produce no Glob results, causing a false rejection. The .git/HEAD sentinel is
+always present in any valid git worktree, including freshly created ones.
 ```
 
 If the worktree path does not exist or is not writable, **fail immediately** — do not create the debate directory, write meta.json, or spawn any agents. Return an error to the caller with the message above. No debate artifacts are created on pre-flight failure.
 
-**Pair definition check**: Verify both `.ratchet/pairs/<name>/generative.md` and `.ratchet/pairs/<name>/adversarial.md` exist (this is also covered in Error Handling below, but checking here prevents wasted work).
+**Pair definition check**: Verify both `.ratchet/pairs/<name>/generative.md` and `.ratchet/pairs/<name>/adversarial.md` exist using the `Glob` tool (this is also covered in Error Handling below, but checking here prevents wasted work).
 
 ### 1. Create Debate Directory
 

--- a/install.sh
+++ b/install.sh
@@ -381,7 +381,7 @@ do_install() {
     echo "  Installed command aliases (rr, rrs, rrt)"
 
     # Install agents alongside commands
-    if [ -d "$SCRIPT_DIR/agents" ] && ls "$SCRIPT_DIR"/agents/*.md >/dev/null 2>&1; then
+    if [ -d "$SCRIPT_DIR/agents" ] && compgen -G "$SCRIPT_DIR/agents/*.md" >/dev/null 2>&1; then
         mkdir -p "$commands_dir/agents" || die "Failed to create agents directory: $commands_dir/agents"
         for agent_file in "$SCRIPT_DIR"/agents/*.md; do
             local agent_name
@@ -396,7 +396,7 @@ do_install() {
     fi
 
     # Copy scripts
-    if [ -d "$SCRIPT_DIR/scripts" ] && ls "$SCRIPT_DIR"/scripts/*.sh >/dev/null 2>&1; then
+    if [ -d "$SCRIPT_DIR/scripts" ] && compgen -G "$SCRIPT_DIR/scripts/*.sh" >/dev/null 2>&1; then
         mkdir -p "$scripts_dir" || die "Failed to create scripts directory: $scripts_dir"
         cp "$SCRIPT_DIR"/scripts/*.sh "$scripts_dir/" || die "Failed to copy script files"
         chmod +x "$scripts_dir"/*.sh || die "Failed to set script permissions"
@@ -417,7 +417,7 @@ do_install() {
 
     # Copy schemas
     local schemas_dir="$target/ratchet-schemas"
-    if [ -d "$SCRIPT_DIR/schemas" ] && ls "$SCRIPT_DIR"/schemas/*.json >/dev/null 2>&1; then
+    if [ -d "$SCRIPT_DIR/schemas" ] && compgen -G "$SCRIPT_DIR/schemas/*.json" >/dev/null 2>&1; then
         if [ -d "$schemas_dir" ]; then
             chmod -R u+w "$schemas_dir" 2>/dev/null || true
             rm -rf "$schemas_dir"
@@ -428,7 +428,7 @@ do_install() {
     fi
 
     # Copy statusline scripts
-    if [ -d "$SCRIPT_DIR/statusline" ] && ls "$SCRIPT_DIR"/statusline/*.sh >/dev/null 2>&1; then
+    if [ -d "$SCRIPT_DIR/statusline" ] && compgen -G "$SCRIPT_DIR/statusline/*.sh" >/dev/null 2>&1; then
         for statusline_file in "$SCRIPT_DIR"/statusline/*.sh; do
             local basename_file
             basename_file="$(basename "$statusline_file")"
@@ -504,13 +504,15 @@ do_uninstall() {
     fi
 
     # Remove statusline scripts
+    local removed_statusline=false
     for statusline_pattern in "$target"/statusline-*.sh; do
         if [ -f "$statusline_pattern" ]; then
             chmod u+w "$statusline_pattern" 2>/dev/null || true
             rm -f "$statusline_pattern"
+            removed_statusline=true
         fi
     done
-    if ls "$target"/statusline-*.sh >/dev/null 2>&1; then
+    if [ "$removed_statusline" = "true" ]; then
         echo "  Removed statusline scripts"
     fi
 

--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -277,7 +277,7 @@
     },
     "pair": {
       "type": "object",
-      "required": ["name", "component", "scope", "enabled"],
+      "required": ["name", "component", "scope"],
       "additionalProperties": false,
       "properties": {
         "name": {

--- a/scripts/auto-watch-hook.sh
+++ b/scripts/auto-watch-hook.sh
@@ -87,7 +87,7 @@ mkdir -p "$LOCK_DIR" || {
 #   1. Prevents duplicate watch-start requests
 #   2. Stores the timestamp of the request for staleness detection
 echo "$$" > "$LOCK_FILE"
-echo "watch_requested_at=$(date -Iseconds)" >> "$LOCK_FILE"
+echo "watch_requested_at=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)" >> "$LOCK_FILE"
 echo "trigger_command=$(echo "$COMMAND" | head -c 200)" >> "$LOCK_FILE"
 
 echo "Info: auto-watch-hook: PR created successfully — watch loop start requested (lock: $LOCK_FILE)" >&2

--- a/scripts/check-active-debates.sh
+++ b/scripts/check-active-debates.sh
@@ -35,7 +35,7 @@ done
 if [ ${#active_debates[@]} -gt 0 ]; then
     echo ""
     echo "Ratchet: ${#active_debates[@]} unresolved debate(s):"
-    for debate in "${active_debates[@]}"; do
+    for debate in "${active_debates[@]+"${active_debates[@]}"}"; do
         echo "  → $debate"
     done
     echo ""

--- a/scripts/check-consensus.sh
+++ b/scripts/check-consensus.sh
@@ -50,7 +50,7 @@ if [ ${#blocking_debates[@]} -gt 0 ]; then
     echo "║  Ratchet: Unresolved debates block this commit      ║"
     echo "╚══════════════════════════════════════════════════════╝"
     echo ""
-    for debate in "${blocking_debates[@]}"; do
+    for debate in "${blocking_debates[@]+"${blocking_debates[@]}"}"; do
         echo "  ✗ $debate"
     done
     echo ""

--- a/scripts/git-pre-commit.sh
+++ b/scripts/git-pre-commit.sh
@@ -43,8 +43,20 @@ if [ -z "${RATCHET_SKIP_VERDICT_CHECK:-}" ]; then
             fi
         fi
 
+        # Cross-platform ISO 8601 to epoch conversion
+        # date -d is GNU-only; macOS (BSD date) uses -j -f instead.
+        iso_to_epoch() {
+            local iso="$1"
+            # Try GNU date first
+            local result
+            result=$(date -d "$iso" +%s 2>/dev/null) && { echo "$result"; return; }
+            # Try BSD date (macOS)
+            result=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null) && { echo "$result"; return; }
+            echo "0"
+        }
+
         VERDICT_OK=false
-        for meta_file in $(ls -t .ratchet/debates/*/meta.json 2>/dev/null); do
+        for meta_file in .ratchet/debates/*/meta.json; do
             [ -f "$meta_file" ] || continue
 
             # Extract verdict
@@ -58,7 +70,7 @@ if [ -z "${RATCHET_SKIP_VERDICT_CHECK:-}" ]; then
             # meta.json stores ISO 8601: "started": "2026-03-28T14:30:00Z"
             started_iso=$(sed -n 's/.*"started"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$meta_file" | head -1)
             if [ -n "$started_iso" ]; then
-                started_epoch=$(date -d "$started_iso" +%s 2>/dev/null || echo "0")
+                started_epoch=$(iso_to_epoch "$started_iso")
             else
                 started_epoch=0
             fi

--- a/skills/guard/SKILL.md
+++ b/skills/guard/SKILL.md
@@ -190,7 +190,7 @@ Guard results are stored as JSON in `.ratchet/guards/<milestone-id>/<issue-ref>/
 }
 ```
 
-These fields are produced by `scripts/run-guards.sh`. When a guard is overridden (via the `override` subcommand), the following fields are patched onto the existing JSON — the original fields are preserved:
+These fields are produced by `.claude/ratchet-scripts/run-guards.sh`. When a guard is overridden (via the `override` subcommand), the following fields are patched onto the existing JSON — the original fields are preserved:
 
 ```json
 {

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -333,13 +333,19 @@ epic:
                      # ref: "discovery-<type>-<timestamp>"   unique ID
                      # title: "<short description>"
                      # description: "<full context and action needed>"
+                     # category: "bug|tech-debt|feature|security|performance|other"
+                     # severity: "critical|major|minor|info"
                      # source: "<origin identifier>"         e.g. "pr-conflict-20"
-                     # created_at: "<ISO timestamp>"
-                     # severity: "high|medium|low"
-                     # status: "pending|done"               set to done after /ratchet:run processes it
-                     # issue_ref: "<issue-ref>"             direct ref to affected issue
-                     # affected_scope: "<human description>"
-                     # retro_type: null|"ci-failure"|"skipped-finding"
+                     # status: "pending|done|promoted|dismissed"
+                     # issue_ref: "<issue-ref or null>"      direct ref to affected issue
+                     # context:
+                     #   milestone: <milestone-id or null>
+                     #   issue: "<issue-ref or null>"
+                     #   debate: "<debate-id or null>"
+                     # pairs: []                             pair names relevant to this discovery
+                     # affected_scope: "<file-glob or null>"
+                     # retro_type: null|"ci-failure"|"skipped-finding"|"review-feedback"
+                     # created_at: "<ISO 8601 timestamp>"
 ```
 
 **Every milestone must have at least one issue.** A simple milestone with a single coherent deliverable has one issue that IS the milestone. This unifies the execution model — there are no special cases. Phase tracking lives on issues, not milestones. Milestone status is derived: `pending` (no issues started), `in_progress` (any issue started), `done` (all issues done).

--- a/skills/run/issue-pipeline.md
+++ b/skills/run/issue-pipeline.md
@@ -48,8 +48,8 @@ ROLE BOUNDARY — You are a debate-runner, NOT a solver:
   You orchestrate debate rounds between generative and adversarial agents.
   You may use Write/Edit ONLY for debate artifacts in .ratchet/debates/,
   .ratchet/escalations/, and .ratchet/reviews/. You NEVER modify source
-  code, tests, or application config. Your tools are: Read, Write, Edit,
-  Agent, AskUserQuestion — with Write/Edit gated to .ratchet/ paths only.
+  code, tests, or application config. Your tools are: Read, Glob, Write, Edit,
+  Agent, AskUserQuestion, TodoWrite — with Write/Edit gated to .ratchet/ paths only.
 
   When spawning agents, enforce these tool boundaries:
     Generative agent: tools = Read, Grep, Glob, Bash, Write, Edit

--- a/skills/tighten/SKILL.md
+++ b/skills/tighten/SKILL.md
@@ -251,7 +251,7 @@ When improvements originated from PR analysis, write to `.ratchet/retros/<timest
 
 #### 5b. Create sidequests for skipped findings
 
-For any skipped finding with severity `major` or `critical` (`fix_applied` is null), add a discovery to `epic.discoveries` in `.ratchet/plan.yaml` via `yq eval -i`. Fields: `ref` (discovery-tighten-TIMESTAMP), `title`, `description` (include evidence), `source`, `created_at`, `severity`, `retro_type: "skipped-finding"`, `status: "pending"`.
+For any skipped finding with severity `major` or `critical` (`fix_applied` is null), add a discovery to `epic.discoveries` in `.ratchet/plan.yaml` via `yq eval -i`. Required fields: `ref` (discovery-tighten-TIMESTAMP), `title`, `description` (include evidence), `category` (map finding type: missing_validation/missing_guard → "tech-debt", missing_pair → "feature", phase_gap → "tech-debt"), `severity` (critical|major|minor|info), `source` ("tighten"), `status: "pending"`, `retro_type: "skipped-finding"`, `created_at` (ISO 8601). Optional: `context`, `pairs`, `affected_scope`, `issue_ref`.
 
 #### 5c. Analyst summary
 

--- a/skills/verdict/SKILL.md
+++ b/skills/verdict/SKILL.md
@@ -155,7 +155,7 @@ fi
 Run the score update script:
 ```bash
 test -f .claude/ratchet-scripts/update-scores.sh \
-  || { echo "Error: update-scores.sh not found. Scores not updated." >&2; }
+  || { echo "Error: update-scores.sh not found. Scores not updated." >&2; exit 1; }
 bash .claude/ratchet-scripts/update-scores.sh <debate-id>
 ```
 

--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -85,9 +85,13 @@ ci_status=$(gh pr view "$pr_num" --json statusCheckRollup -q '.statusCheckRollup
     \"category\": \"bug\",
     \"severity\": \"critical\",
     \"source\": \"pr-conflict-$pr_num\",
-    \"created_at\": \"$(date -Iseconds)\",
     \"status\": \"pending\",
-    \"issue_ref\": \"$issue_ref\"
+    \"issue_ref\": \"$issue_ref\",
+    \"context\": {\"milestone\": $milestone_id, \"issue\": \"$issue_ref\", \"debate\": null},
+    \"pairs\": [],
+    \"affected_scope\": null,
+    \"retro_type\": null,
+    \"created_at\": \"$(date -Iseconds)\"
   }]" .ratchet/plan.yaml
   ```
 - Report: "Merge conflict detected: PR #[N] (issue [ref]) — discovery created"
@@ -96,6 +100,9 @@ ci_status=$(gh pr view "$pr_num" --json statusCheckRollup -q '.statusCheckRollup
 - Check if discovery already exists: `epic.discoveries[] | select(.source == "pr-ci-failure-<pr_num>")`
 - If not, create discovery:
   ```bash
+  issue_ref=$(yq eval ".epic.milestones[].issues[] | select(.pr == \"$pr_url\") | .ref" .ratchet/plan.yaml)
+  milestone_id=$(yq eval ".epic.milestones[] | select(.issues[] | .pr == \"$pr_url\") | .id" .ratchet/plan.yaml | head -1)
+  milestone_id_value=$([ -n "$milestone_id" ] && echo "$milestone_id" || echo "null")
   yq eval -i ".epic.discoveries += [{
     \"ref\": \"discovery-ci-$(date +%s)\",
     \"title\": \"CI failure in PR #$pr_num\",
@@ -103,10 +110,13 @@ ci_status=$(gh pr view "$pr_num" --json statusCheckRollup -q '.statusCheckRollup
     \"category\": \"tech-debt\",
     \"severity\": \"major\",
     \"source\": \"pr-ci-failure-$pr_num\",
-    \"created_at\": \"$(date -Iseconds)\",
     \"status\": \"pending\",
     \"issue_ref\": \"$issue_ref\",
-    \"retro_type\": \"ci-failure\"
+    \"context\": {\"milestone\": $milestone_id_value, \"issue\": \"$issue_ref\", \"debate\": null},
+    \"pairs\": [],
+    \"affected_scope\": null,
+    \"retro_type\": \"ci-failure\",
+    \"created_at\": \"$(date -Iseconds)\"
   }]" .ratchet/plan.yaml
   ```
 - Report: "CI failure detected: PR #[N] ([failed checks]) — discovery created"
@@ -157,28 +167,35 @@ Warning: Could not determine authenticated GitHub user — bot comment filtering
 
 **For each actionable comment** (after bot filtering), create a structured feedback entry in plan.yaml:
 ```bash
+# Encode review metadata in description since the schema's additionalProperties: false
+# prohibits extra top-level fields. Use source field for deduplication.
+# Note: use null (no quotes) for empty affected_scope to produce YAML null, not string "null"
+affected_scope_value=$([ -n "$comment_path" ] && echo "\"$comment_path\"" || echo "null")
+milestone_id=$(yq eval ".epic.milestones[] | select(.issues[] | .pr == \"$pr_url\") | .id" .ratchet/plan.yaml | head -1)
+milestone_id_value=$([ -n "$milestone_id" ] && echo "$milestone_id" || echo "null")
+
 yq eval -i ".epic.discoveries += [{
   \"ref\": \"feedback-review-${pr_num}-$(date +%s)\",
   \"title\": \"Review feedback on PR #${pr_num}: $(echo "$comment_body" | head -c 60)\",
-  \"description\": \"$comment_body\",
-  \"source\": \"pr-review-${pr_num}\",
-  \"created_at\": \"$(date -Iseconds)\",
+  \"description\": \"Author: $comment_author | File: ${comment_path:-top-level} | Category: $category\n\n$comment_body\",
+  \"category\": \"tech-debt\",
   \"severity\": \"major\",
+  \"source\": \"pr-review-${pr_num}-${comment_id}\",
   \"status\": \"pending\",
   \"retro_type\": \"review-feedback\",
   \"issue_ref\": \"$issue_ref\",
-  \"review_comment_id\": $comment_id,
-  \"review_file_path\": \"$comment_path\",
-  \"review_author\": \"$comment_author\",
-  \"review_category\": \"$category\"
+  \"context\": {
+    \"milestone\": $milestone_id_value,
+    \"issue\": \"$issue_ref\",
+    \"debate\": null
+  },
+  \"pairs\": [],
+  \"affected_scope\": $affected_scope_value,
+  \"created_at\": \"$(date -Iseconds)\"
 }]" .ratchet/plan.yaml
 ```
 
-The feedback discovery uses flat top-level fields prefixed with `review_` to remain consistent with the existing discovery schema pattern (all flat key-value pairs, no nested objects). Fields:
-- `review_comment_id`: The GitHub comment ID for deduplication and linking
-- `review_file_path`: The file path the comment is attached to (null for top-level reviews)
-- `review_author`: The GitHub username who left the comment
-- `review_category`: One of `requested_change`, `question`, `code_suggestion`
+Review metadata fields (author, file path, comment category) are encoded in the `description` field and `source` field since the discovery schema (`additionalProperties: false`) prohibits extra top-level fields. Use `source: "pr-review-<pr_num>-<comment_id>"` for deduplication — the comment ID in the source uniquely identifies each feedback entry.
 
 - Report: "Review feedback detected: PR #[N] — [count] actionable comment(s) from [author(s)]"
 


### PR DESCRIPTION
## Summary

- 4 parallel debates ran with caveman `full` intensity across all agent roles
- All 4 pairs reached ACCEPT in 2 rounds (439K total tokens)
- 17 fixes across 14 files from skill-coherence, script-robustness, agent-effectiveness, and schema-correctness pairs

### Schema correctness
- Remove `enabled` from `pair.required` — contradicts `default: true` in JSON Schema

### Script robustness
- Fix SC2012/SC2046 shellcheck violations in git-pre-commit.sh
- Add macOS portability for `date -d` and `date -Iseconds`
- Fix bash 3.2 empty array expansion under `set -u`
- Replace `ls` glob guards with `compgen -G` in install.sh
- Fix vestigial always-false check in install.sh uninstall

### Skill coherence
- Fix discovery schema compliance in init, watch, tighten skills
- Fix stale script path in guard skill
- Fix error handling in verdict skill

### Agent effectiveness
- Add Glob to debate-runner frontmatter tools
- Fix worktree validation to use available tools (no Bash)
- Add read-only spawn mode docs to analyst agent
- Update debate-runner tool list in issue-pipeline context block

## Test plan
- [ ] `jq empty schemas/workflow.schema.json` passes
- [ ] shellcheck passes on all modified scripts
- [ ] Existing workflow.yaml validates against updated schema