### PR TITLE
Fix errcheck violations in monitor production code

### DIFF
--- a/monitor/cmd/tui/main.go
+++ b/monitor/cmd/tui/main.go
@@ -44,7 +44,7 @@ func main() {
 		slog.Error("failed to create tui app", "error", err)
 		os.Exit(1)
 	}
-	defer tuiApp.Close()
+	defer func() { _ = tuiApp.Close() }()
 
 	// Wire SSE-driven re-rendering: store changes trigger TUI re-render.
 	app.SetOnUpdate(func() {

--- a/monitor/internal/handler/sse.go
+++ b/monitor/internal/handler/sse.go
@@ -54,7 +54,7 @@ func SSEHandler(broker *sse.Broker) http.Handler {
 		// Send an SSE comment to establish the stream. Without this,
 		// browsers keep EventSource in "connecting" state until the
 		// first real data arrives.
-		fmt.Fprint(w, ": ok\n\n")
+		_, _ = fmt.Fprint(w, ": ok\n\n")
 		if flusher != nil {
 			flusher.Flush()
 		}
@@ -73,9 +73,9 @@ func SSEHandler(broker *sse.Broker) http.Handler {
 					slog.Error("failed to marshal event", "error", err)
 					continue
 				}
-				fmt.Fprintf(w, "event: %s\n", ev.Type)
-				fmt.Fprintf(w, "id: %d\n", ev.ID)
-				fmt.Fprintf(w, "data: %s\n\n", data)
+				_, _ = fmt.Fprintf(w, "event: %s\n", ev.Type)
+				_, _ = fmt.Fprintf(w, "id: %d\n", ev.ID)
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
 				if flusher != nil {
 					flusher.Flush()
 				}

--- a/monitor/internal/tui/client/client.go
+++ b/monitor/internal/tui/client/client.go
@@ -89,7 +89,7 @@ func (c *Client) get(ctx context.Context, path string, out any) error {
 	if err != nil {
 		return fmt.Errorf("GET %s: %w", path, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("unexpected status %d for %s", resp.StatusCode, path)
 	}
@@ -246,7 +246,7 @@ func (c *Client) sseConnect(ctx context.Context, ch chan<- SSEEvent) (bool, erro
 	if err != nil {
 		return false, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	receivedEvents := false
 	scanner := bufio.NewScanner(resp.Body)

--- a/monitor/internal/watcher/debounce.go
+++ b/monitor/internal/watcher/debounce.go
@@ -52,7 +52,7 @@ func NewWithOptions(dir string, opts ...Option) (*Watcher, error) {
 		return nil
 	})
 	if err != nil {
-		fsw.Close()
+		_ = fsw.Close()
 		return nil, fmt.Errorf("walk directory %q: %w", dir, err)
 	}
 


### PR DESCRIPTION
## Summary

- Fix unchecked error returns in production Go files flagged by golangci-lint errcheck
- Files: `cmd/tui/main.go`, `internal/handler/sse.go`, `internal/tui/client/client.go`, `internal/watcher/debounce.go`
- Uses `_ =` pattern for best-effort writes (SSE) and deferred closes

## Milestone

M1: Lint compliance — part of ratchet monitor quality improvements epic

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` shows no errcheck in production files