### PR TITLE
Fix staticcheck violations in monitor

### DIFF
--- a/monitor/internal/tui/client/sse_client_test.go
+++ b/monitor/internal/tui/client/sse_client_test.go
@@ -375,10 +375,7 @@ func TestSSEClientExponentialBackoff(t *testing.T) {
 
 	// Wait for at least 4 connections.
 	deadline := time.After(8 * time.Second)
-	for {
-		if connectCount.Load() >= 4 {
-			break
-		}
+	for connectCount.Load() < 4 {
 		select {
 		case <-deadline:
 			t.Fatalf("only got %d connections, expected >= 4", connectCount.Load())

--- a/monitor/internal/tui/views/pairs_viewmodel.go
+++ b/monitor/internal/tui/views/pairs_viewmodel.go
@@ -200,10 +200,10 @@ func (vm *PairsViewModel) applyFilter() {
 		if ws != "" && p.Workspace != ws {
 			continue
 		}
-		if q != "" && !(strings.Contains(strings.ToLower(p.Name), q) ||
-			strings.Contains(strings.ToLower(p.Component), q) ||
-			strings.Contains(strings.ToLower(p.Phase), q) ||
-			strings.Contains(strings.ToLower(p.Status), q)) {
+		if q != "" && !strings.Contains(strings.ToLower(p.Name), q) &&
+			!strings.Contains(strings.ToLower(p.Component), q) &&
+			!strings.Contains(strings.ToLower(p.Phase), q) &&
+			!strings.Contains(strings.ToLower(p.Status), q) {
 			continue
 		}
 		vm.filtered = append(vm.filtered, p)


### PR DESCRIPTION
## Summary

- Fix QF1006 in `internal/tui/client/sse_client_test.go` — lift break condition into loop
- Fix QF1001 in `internal/tui/views/pairs_viewmodel.go` — apply De Morgan's law

## Milestone

M1: Lint compliance — part of ratchet monitor quality improvements epic

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` shows no staticcheck violations