### PR TITLE
Add .golangci.yml and fix remaining errcheck violation

### DIFF
--- a/monitor/.golangci.yml
+++ b/monitor/.golangci.yml
@@ -1,0 +1,12 @@
+version: "2"
+
+linters:
+  enable:
+    - errcheck
+    - staticcheck
+    - govet
+  disable:
+    - unused
+
+run:
+  timeout: 5m

--- a/monitor/cmd/monitor/main.go
+++ b/monitor/cmd/monitor/main.go
@@ -75,7 +75,7 @@ func main() {
 		}
 		log.Fatalf("failed to create watcher for %q: %v", dir, err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	broker := sse.NewBroker()
 	defer broker.Close()

--- a/monitor/cmd/tui/main.go
+++ b/monitor/cmd/tui/main.go
@@ -44,7 +44,7 @@ func main() {
 		slog.Error("failed to create tui app", "error", err)
 		os.Exit(1)
 	}
-	defer tuiApp.Close()
+	defer func() { _ = tuiApp.Close() }()
 
 	// Wire SSE-driven re-rendering: store changes trigger TUI re-render.
 	app.SetOnUpdate(func() {

--- a/monitor/internal/datasource/file_test.go
+++ b/monitor/internal/datasource/file_test.go
@@ -40,7 +40,9 @@ pairs:
     enabled: true
 guards: []
 `
-	os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflow), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	// plan.yaml
 	plan := `epic:
@@ -70,11 +72,15 @@ guards: []
     phase: build
     started: "2026-03-14"
 `
-	os.WriteFile(filepath.Join(dir, "plan.yaml"), []byte(plan), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "plan.yaml"), []byte(plan), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	// debates directory with meta.json files
 	debate1Dir := filepath.Join(dir, "debates", "api-design-1")
-	os.MkdirAll(debate1Dir, 0o755)
+	if err := os.MkdirAll(debate1Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	started := time.Date(2026, 3, 13, 16, 45, 0, 0, time.UTC)
 	meta1 := map[string]any{
@@ -91,10 +97,14 @@ guards: []
 		"verdict":     "ACCEPT",
 	}
 	data1, _ := json.Marshal(meta1)
-	os.WriteFile(filepath.Join(debate1Dir, "meta.json"), data1, 0o644)
+	if err := os.WriteFile(filepath.Join(debate1Dir, "meta.json"), data1, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	debate2Dir := filepath.Join(dir, "debates", "sse-test-1")
-	os.MkdirAll(filepath.Join(debate2Dir, "rounds"), 0o755)
+	if err := os.MkdirAll(filepath.Join(debate2Dir, "rounds"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	meta2 := map[string]any{
 		"id":          "sse-test-1",
@@ -108,12 +118,20 @@ guards: []
 		"started":     started.Add(2 * time.Hour).Format(time.RFC3339),
 	}
 	data2, _ := json.Marshal(meta2)
-	os.WriteFile(filepath.Join(debate2Dir, "meta.json"), data2, 0o644)
+	if err := os.WriteFile(filepath.Join(debate2Dir, "meta.json"), data2, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	// Round files.
-	os.WriteFile(filepath.Join(debate2Dir, "rounds", "round-1-generative.md"), []byte("# Round 1 generative\nContent here."), 0o644)
-	os.WriteFile(filepath.Join(debate2Dir, "rounds", "round-1-adversarial.md"), []byte("# Round 1 adversarial\nReview here."), 0o644)
-	os.WriteFile(filepath.Join(debate2Dir, "rounds", "round-2-generative.md"), []byte("# Round 2 generative\nMore content."), 0o644)
+	if err := os.WriteFile(filepath.Join(debate2Dir, "rounds", "round-1-generative.md"), []byte("# Round 1 generative\nContent here."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(debate2Dir, "rounds", "round-1-adversarial.md"), []byte("# Round 1 adversarial\nReview here."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(debate2Dir, "rounds", "round-2-generative.md"), []byte("# Round 2 generative\nMore content."), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	return dir
 }
@@ -293,13 +311,17 @@ func TestFileDataSource_Scores(t *testing.T) {
 
 	// Create scores directory and file.
 	scoresDir := filepath.Join(dir, "scores")
-	os.MkdirAll(scoresDir, 0o755)
+	if err := os.MkdirAll(scoresDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	lines := `{"timestamp":"2026-03-14T10:00:00Z","debate_id":"d1","pair":"api-design","milestone":1,"rounds_to_consensus":2,"escalated":false,"issues_found":3,"issues_resolved":3}
 {"timestamp":"2026-03-15T12:00:00Z","debate_id":"d2","pair":"sse-correctness","milestone":2,"rounds_to_consensus":1,"escalated":false,"issues_found":1,"issues_resolved":1}
 {"timestamp":"2026-03-14T14:00:00Z","debate_id":"d3","pair":"api-design","milestone":2,"rounds_to_consensus":3,"escalated":true,"issues_found":5,"issues_resolved":2}
 `
-	os.WriteFile(filepath.Join(scoresDir, "scores.jsonl"), []byte(lines), 0o644)
+	if err := os.WriteFile(filepath.Join(scoresDir, "scores.jsonl"), []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	// All scores, sorted by timestamp descending.
 	result, err := ds.Scores("")
@@ -327,12 +349,16 @@ func TestFileDataSource_Scores_FilterByPair(t *testing.T) {
 	ds := NewFileDataSource(dir)
 
 	scoresDir := filepath.Join(dir, "scores")
-	os.MkdirAll(scoresDir, 0o755)
+	if err := os.MkdirAll(scoresDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	lines := `{"timestamp":"2026-03-14T10:00:00Z","debate_id":"d1","pair":"api-design","milestone":1,"rounds_to_consensus":2,"escalated":false,"issues_found":3,"issues_resolved":3}
 {"timestamp":"2026-03-15T12:00:00Z","debate_id":"d2","pair":"sse-correctness","milestone":2,"rounds_to_consensus":1,"escalated":false,"issues_found":1,"issues_resolved":1}
 `
-	os.WriteFile(filepath.Join(scoresDir, "scores.jsonl"), []byte(lines), 0o644)
+	if err := os.WriteFile(filepath.Join(scoresDir, "scores.jsonl"), []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	result, err := ds.Scores("api-design")
 	if err != nil {
@@ -370,8 +396,12 @@ func TestFileDataSource_Scores_NoFile(t *testing.T) {
 func TestFileDataSource_Scores_EmptyFile(t *testing.T) {
 	dir := t.TempDir()
 	scoresDir := filepath.Join(dir, "scores")
-	os.MkdirAll(scoresDir, 0o755)
-	os.WriteFile(filepath.Join(scoresDir, "scores.jsonl"), []byte(""), 0o644)
+	if err := os.MkdirAll(scoresDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scoresDir, "scores.jsonl"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	ds := NewFileDataSource(dir)
 	result, err := ds.Scores("")
@@ -390,7 +420,9 @@ func TestFileDataSource_Scores_EmptyFile(t *testing.T) {
 func TestFileDataSource_Scores_FileTooLarge(t *testing.T) {
 	dir := t.TempDir()
 	scoresDir := filepath.Join(dir, "scores")
-	os.MkdirAll(scoresDir, 0o755)
+	if err := os.MkdirAll(scoresDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	// Create a file that exceeds maxScoresFileSize (10 MiB).
 	f, err := os.Create(filepath.Join(scoresDir, "scores.jsonl"))
@@ -400,10 +432,12 @@ func TestFileDataSource_Scores_FileTooLarge(t *testing.T) {
 	// Write just over the limit. We don't need valid JSONL — the size check
 	// happens before parsing.
 	if err := f.Truncate(maxScoresFileSize + 1); err != nil {
-		f.Close()
+		_ = f.Close()
 		t.Fatalf("truncate: %v", err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	ds := NewFileDataSource(dir)
 	_, err = ds.Scores("")
@@ -418,7 +452,9 @@ func TestFileDataSource_Scores_FileTooLarge(t *testing.T) {
 func TestFileDataSource_Scores_SkipsMalformedLines(t *testing.T) {
 	dir := t.TempDir()
 	scoresDir := filepath.Join(dir, "scores")
-	os.MkdirAll(scoresDir, 0o755)
+	if err := os.MkdirAll(scoresDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	// Mix of valid and malformed lines.
 	lines := `{"timestamp":"2026-03-14T10:00:00Z","debate_id":"d1","pair":"api-design","milestone":1,"rounds_to_consensus":2,"escalated":false,"issues_found":3,"issues_resolved":3}
@@ -426,7 +462,9 @@ func TestFileDataSource_Scores_SkipsMalformedLines(t *testing.T) {
 {"timestamp":"2026-03-15T12:00:00Z","debate_id":"d2","pair":"sse-correctness","milestone":2,"rounds_to_consensus":1,"escalated":false,"issues_found":1,"issues_resolved":1}
 also not json
 `
-	os.WriteFile(filepath.Join(scoresDir, "scores.jsonl"), []byte(lines), 0o644)
+	if err := os.WriteFile(filepath.Join(scoresDir, "scores.jsonl"), []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	ds := NewFileDataSource(dir)
 	result, err := ds.Scores("")
@@ -445,13 +483,17 @@ also not json
 func TestFileDataSource_Scores_FilterByPairWithMalformedLines(t *testing.T) {
 	dir := t.TempDir()
 	scoresDir := filepath.Join(dir, "scores")
-	os.MkdirAll(scoresDir, 0o755)
+	if err := os.MkdirAll(scoresDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	lines := `{"timestamp":"2026-03-14T10:00:00Z","debate_id":"d1","pair":"api-design","milestone":1,"rounds_to_consensus":2,"escalated":false,"issues_found":3,"issues_resolved":3}
 {malformed}
 {"timestamp":"2026-03-15T12:00:00Z","debate_id":"d2","pair":"sse-correctness","milestone":2,"rounds_to_consensus":1,"escalated":false,"issues_found":1,"issues_resolved":1}
 `
-	os.WriteFile(filepath.Join(scoresDir, "scores.jsonl"), []byte(lines), 0o644)
+	if err := os.WriteFile(filepath.Join(scoresDir, "scores.jsonl"), []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	ds := NewFileDataSource(dir)
 	result, err := ds.Scores("api-design")
@@ -470,11 +512,15 @@ func TestFileDataSource_Scores_FilterByPairWithMalformedLines(t *testing.T) {
 func TestFileDataSource_Scores_NonexistentPairReturnsEmpty(t *testing.T) {
 	dir := t.TempDir()
 	scoresDir := filepath.Join(dir, "scores")
-	os.MkdirAll(scoresDir, 0o755)
+	if err := os.MkdirAll(scoresDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	lines := `{"timestamp":"2026-03-14T10:00:00Z","debate_id":"d1","pair":"api-design","milestone":1,"rounds_to_consensus":2,"escalated":false,"issues_found":3,"issues_resolved":3}
 `
-	os.WriteFile(filepath.Join(scoresDir, "scores.jsonl"), []byte(lines), 0o644)
+	if err := os.WriteFile(filepath.Join(scoresDir, "scores.jsonl"), []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	ds := NewFileDataSource(dir)
 	result, err := ds.Scores("nonexistent-pair")
@@ -515,7 +561,9 @@ func TestFileDataSource_Pairs_MissingWorkflow(t *testing.T) {
 // empty slice (not an error) when workflow.yaml contains invalid YAML.
 func TestFileDataSource_Pairs_MalformedWorkflow(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte("{{{{not yaml"), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte("{{{{not yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	result, err := ds.Pairs("")
@@ -540,7 +588,9 @@ func TestFileDataSource_Pairs_PermissionDenied(t *testing.T) {
 	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "workflow.yaml")
-	os.WriteFile(path, []byte("version: 2\n"), 0o000)
+	if err := os.WriteFile(path, []byte("version: 2\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	_, err := ds.Pairs("")
@@ -611,7 +661,9 @@ workspaces:
     path: /home/dev/backend
 pairs: []
 `
-	os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflow), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	result, err := ds.Workspaces()
@@ -667,7 +719,9 @@ progress:
   adapter: none
 pairs: []
 `
-	os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflow), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	result, err := ds.Workspaces()
@@ -686,7 +740,9 @@ pairs: []
 // TestFileDataSource_Workspaces_MalformedWorkflow verifies graceful degradation.
 func TestFileDataSource_Workspaces_MalformedWorkflow(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte("{{{{not yaml"), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte("{{{{not yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	result, err := ds.Workspaces()
@@ -709,7 +765,9 @@ func TestFileDataSource_Workspaces_PermissionDenied(t *testing.T) {
 	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "workflow.yaml")
-	os.WriteFile(path, []byte("version: 2\n"), 0o000)
+	if err := os.WriteFile(path, []byte("version: 2\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	_, err := ds.Workspaces()
@@ -733,7 +791,9 @@ func TestFileDataSource_Status_NilCurrentFocus(t *testing.T) {
       status: done
       done_when: "done"
 `
-	os.WriteFile(filepath.Join(dir, "plan.yaml"), []byte(plan), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "plan.yaml"), []byte(plan), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	result, err := ds.Status()
@@ -754,8 +814,12 @@ func TestFileDataSource_Status_NilCurrentFocus(t *testing.T) {
 func TestFileDataSource_Debate_MalformedMeta(t *testing.T) {
 	dir := t.TempDir()
 	debateDir := filepath.Join(dir, "debates", "bad-debate")
-	os.MkdirAll(debateDir, 0o755)
-	os.WriteFile(filepath.Join(debateDir, "meta.json"), []byte("{not valid json"), 0o644)
+	if err := os.MkdirAll(debateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(debateDir, "meta.json"), []byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	_, err := ds.Debate("bad-debate")
@@ -772,12 +836,18 @@ func TestFileDataSource_Debates_SkipsMalformed(t *testing.T) {
 
 	// Create a malformed meta.json
 	debateDir := filepath.Join(dir, "debates", "bad-debate")
-	os.MkdirAll(debateDir, 0o755)
-	os.WriteFile(filepath.Join(debateDir, "meta.json"), []byte("{bad json"), 0o644)
+	if err := os.MkdirAll(debateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(debateDir, "meta.json"), []byte("{bad json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	// Create a valid meta.json
 	goodDir := filepath.Join(dir, "debates", "good-debate")
-	os.MkdirAll(goodDir, 0o755)
+	if err := os.MkdirAll(goodDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	meta := map[string]any{
 		"id":          "good-debate",
 		"pair":        "test",
@@ -790,7 +860,9 @@ func TestFileDataSource_Debates_SkipsMalformed(t *testing.T) {
 		"started":     time.Now().Format(time.RFC3339),
 	}
 	data, _ := json.Marshal(meta)
-	os.WriteFile(filepath.Join(goodDir, "meta.json"), data, 0o644)
+	if err := os.WriteFile(filepath.Join(goodDir, "meta.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	ds := NewFileDataSource(dir)
 	result, err := ds.Debates("")
@@ -874,7 +946,9 @@ func TestFileDataSource_Plan_V2WithIssues(t *testing.T) {
     phase: test
     started: "2026-03-16"
 `
-	os.WriteFile(filepath.Join(dir, "plan.yaml"), []byte(planV2), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "plan.yaml"), []byte(planV2), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	ds := NewFileDataSource(dir)
 	result, err := ds.Plan()
@@ -941,7 +1015,9 @@ max_rounds: 3
 escalation: human
 max_regressions: 5
 `
-	os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflow), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	plan := `epic:
   name: test-epic
@@ -951,7 +1027,9 @@ max_regressions: 5
       status: in_progress
       regressions: 3
 `
-	os.WriteFile(filepath.Join(dir, "plan.yaml"), []byte(plan), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "plan.yaml"), []byte(plan), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	ds := NewFileDataSource(dir)
 	result, err := ds.Plan()
@@ -1006,7 +1084,9 @@ func TestFileDataSource_Status_V2WithIssue(t *testing.T) {
     phase: test
     started: "2026-03-16"
 `
-	os.WriteFile(filepath.Join(dir, "plan.yaml"), []byte(planV2), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "plan.yaml"), []byte(planV2), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	ds := NewFileDataSource(dir)
 	result, err := ds.Status()
@@ -1061,7 +1141,9 @@ pairs:
 // data when the workspace is listed in workflow.yaml.
 func TestFileDataSource_Pairs_KnownWorkspace(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflowWithWorkspaces()), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflowWithWorkspaces()), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	result, err := ds.Pairs("frontend")
@@ -1081,7 +1163,9 @@ func TestFileDataSource_Pairs_KnownWorkspace(t *testing.T) {
 // returns data for the second listed workspace.
 func TestFileDataSource_Pairs_KnownWorkspace_Second(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflowWithWorkspaces()), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflowWithWorkspaces()), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	result, err := ds.Pairs("backend")
@@ -1101,7 +1185,9 @@ func TestFileDataSource_Pairs_KnownWorkspace_Second(t *testing.T) {
 // returns a NotFoundError with Resource="workspace".
 func TestFileDataSource_Pairs_UnknownWorkspace(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflowWithWorkspaces()), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflowWithWorkspaces()), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	_, err := ds.Pairs("nonexistent")
@@ -1144,7 +1230,9 @@ func TestFileDataSource_Pairs_WorkspaceOnMissingFile(t *testing.T) {
 // an empty 200. The caller explicitly named a workspace; we cannot validate it.
 func TestFileDataSource_Pairs_MalformedWorkflow_WithWorkspace(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte("{{{{not yaml"), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte("{{{{not yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	_, err := ds.Pairs("frontend")
@@ -1169,7 +1257,9 @@ max_rounds: 3
 escalation: human
 pairs: []
 `
-	os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflow), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	_, err := ds.Pairs("frontend")
@@ -1186,11 +1276,15 @@ pairs: []
 // the debate list when the workspace is valid.
 func TestFileDataSource_Debates_KnownWorkspace(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflowWithWorkspaces()), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflowWithWorkspaces()), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	// Create one debate.
 	debateDir := filepath.Join(dir, "debates", "test-debate-1")
-	os.MkdirAll(debateDir, 0o755)
+	if err := os.MkdirAll(debateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	meta := map[string]any{
 		"id":         "test-debate-1",
 		"pair":       "api-design",
@@ -1202,7 +1296,9 @@ func TestFileDataSource_Debates_KnownWorkspace(t *testing.T) {
 		"started":    time.Now().Format(time.RFC3339),
 	}
 	data, _ := json.Marshal(meta)
-	os.WriteFile(filepath.Join(debateDir, "meta.json"), data, 0o644)
+	if err := os.WriteFile(filepath.Join(debateDir, "meta.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	ds := NewFileDataSource(dir)
 
@@ -1223,7 +1319,9 @@ func TestFileDataSource_Debates_KnownWorkspace(t *testing.T) {
 // returns a NotFoundError with Resource="workspace".
 func TestFileDataSource_Debates_UnknownWorkspace(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflowWithWorkspaces()), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte(workflowWithWorkspaces()), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ds := NewFileDataSource(dir)
 
 	_, err := ds.Debates("nonexistent")

--- a/monitor/internal/handler/sse.go
+++ b/monitor/internal/handler/sse.go
@@ -54,7 +54,7 @@ func SSEHandler(broker *sse.Broker) http.Handler {
 		// Send an SSE comment to establish the stream. Without this,
 		// browsers keep EventSource in "connecting" state until the
 		// first real data arrives.
-		fmt.Fprint(w, ": ok\n\n")
+		_, _ = fmt.Fprint(w, ": ok\n\n")
 		if flusher != nil {
 			flusher.Flush()
 		}
@@ -73,9 +73,9 @@ func SSEHandler(broker *sse.Broker) http.Handler {
 					slog.Error("failed to marshal event", "error", err)
 					continue
 				}
-				fmt.Fprintf(w, "event: %s\n", ev.Type)
-				fmt.Fprintf(w, "id: %d\n", ev.ID)
-				fmt.Fprintf(w, "data: %s\n\n", data)
+				_, _ = fmt.Fprintf(w, "event: %s\n", ev.Type)
+				_, _ = fmt.Fprintf(w, "id: %d\n", ev.ID)
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
 				if flusher != nil {
 					flusher.Flush()
 				}

--- a/monitor/internal/tui/client/client.go
+++ b/monitor/internal/tui/client/client.go
@@ -89,7 +89,7 @@ func (c *Client) get(ctx context.Context, path string, out any) error {
 	if err != nil {
 		return fmt.Errorf("GET %s: %w", path, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("unexpected status %d for %s", resp.StatusCode, path)
 	}
@@ -246,7 +246,7 @@ func (c *Client) sseConnect(ctx context.Context, ch chan<- SSEEvent) (bool, erro
 	if err != nil {
 		return false, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	receivedEvents := false
 	scanner := bufio.NewScanner(resp.Body)

--- a/monitor/internal/tui/client/rest_client_test.go
+++ b/monitor/internal/tui/client/rest_client_test.go
@@ -17,7 +17,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 
 	mux.HandleFunc("GET /api/pairs", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]PairStatus{
+		_ = json.NewEncoder(w).Encode([]PairStatus{
 			{Name: "lint-review", Component: "linter", Phase: "test", Scope: "module", Enabled: true, Active: true, Status: "debating"},
 			{Name: "sec-audit", Component: "security", Phase: "review", Scope: "repo", Enabled: true, Active: false, Status: "idle"},
 		})
@@ -26,7 +26,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 	mux.HandleFunc("GET /api/debates", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		started := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
-		json.NewEncoder(w).Encode([]DebateMeta{
+		_ = json.NewEncoder(w).Encode([]DebateMeta{
 			{ID: "d-001", Pair: "lint-review", Phase: "test", Milestone: 6, Files: []string{"main.go"}, Status: "active", RoundCount: 2, MaxRounds: 5, Started: started},
 		})
 	})
@@ -35,12 +35,12 @@ func newTestServer(t *testing.T) *httptest.Server {
 		id := r.PathValue("id")
 		if id != "d-001" {
 			w.WriteHeader(http.StatusNotFound)
-			json.NewEncoder(w).Encode(map[string]string{"error": "debate not found"})
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "debate not found"})
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		started := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
-		json.NewEncoder(w).Encode(DebateWithRounds{
+		_ = json.NewEncoder(w).Encode(DebateWithRounds{
 			DebateMeta: DebateMeta{ID: "d-001", Pair: "lint-review", Phase: "test", Milestone: 6, Files: []string{"main.go"}, Status: "active", RoundCount: 2, MaxRounds: 5, Started: started},
 			Rounds: []Round{
 				{Number: 1, Role: "challenger", Content: "Found issue in error handling"},
@@ -51,7 +51,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 
 	mux.HandleFunc("GET /api/plan", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(Plan{
+		_ = json.NewEncoder(w).Encode(Plan{
 			Epic: EpicConfig{
 				Name:        "ratchet-monitor",
 				Description: "Real-time dashboard",
@@ -65,20 +65,20 @@ func newTestServer(t *testing.T) *httptest.Server {
 
 	mux.HandleFunc("GET /api/status", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(StatusInfo{MilestoneID: 6, MilestoneName: "TUI App Shell", Phase: "test"})
+		_ = json.NewEncoder(w).Encode(StatusInfo{MilestoneID: 6, MilestoneName: "TUI App Shell", Phase: "test"})
 	})
 
 	mux.HandleFunc("GET /api/scores", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		ts := time.Date(2026, 3, 15, 9, 0, 0, 0, time.UTC)
-		json.NewEncoder(w).Encode([]ScoreEntry{
+		_ = json.NewEncoder(w).Encode([]ScoreEntry{
 			{Timestamp: ts, DebateID: "d-001", Pair: "lint-review", Milestone: 6, RoundsToConsensus: 3, Escalated: false, IssuesFound: 2, IssuesResolved: 2},
 		})
 	})
 
 	mux.HandleFunc("GET /api/workspaces", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]Workspace{
+		_ = json.NewEncoder(w).Encode([]Workspace{
 			{Name: "frontend", Path: "/home/dev/frontend"},
 			{Name: "backend", Path: "/home/dev/backend"},
 		})
@@ -86,7 +86,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(HealthStatus{Status: "ok"})
+		_ = json.NewEncoder(w).Encode(HealthStatus{Status: "ok"})
 	})
 
 	return httptest.NewServer(mux)
@@ -230,7 +230,7 @@ func TestFetchScores(t *testing.T) {
 		receivedPair = r.URL.Query().Get("pair")
 		w.Header().Set("Content-Type", "application/json")
 		ts := time.Date(2026, 3, 15, 9, 0, 0, 0, time.UTC)
-		json.NewEncoder(w).Encode([]ScoreEntry{
+		_ = json.NewEncoder(w).Encode([]ScoreEntry{
 			{Timestamp: ts, DebateID: "d-001", Pair: "lint-review", Milestone: 6, RoundsToConsensus: 3, Escalated: false, IssuesFound: 2, IssuesResolved: 2},
 		})
 	}))
@@ -297,7 +297,7 @@ func TestContextCancellation(t *testing.T) {
 func TestServerError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "internal server error"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "internal server error"})
 	}))
 	defer srv.Close()
 
@@ -339,7 +339,7 @@ func TestFetchWorkspaces(t *testing.T) {
 func TestMalformedJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{invalid json`))
+		_, _ = w.Write([]byte(`{invalid json`))
 	}))
 	defer srv.Close()
 

--- a/monitor/internal/tui/client/sse_client_test.go
+++ b/monitor/internal/tui/client/sse_client_test.go
@@ -375,10 +375,7 @@ func TestSSEClientExponentialBackoff(t *testing.T) {
 
 	// Wait for at least 4 connections.
 	deadline := time.After(8 * time.Second)
-	for {
-		if connectCount.Load() >= 4 {
-			break
-		}
+	for connectCount.Load() < 4 {
 		select {
 		case <-deadline:
 			t.Fatalf("only got %d connections, expected >= 4", connectCount.Load())

--- a/monitor/internal/tui/client/sse_client_test.go
+++ b/monitor/internal/tui/client/sse_client_test.go
@@ -23,7 +23,7 @@ func sseHandler(events []string) http.HandlerFunc {
 			return
 		}
 		for _, ev := range events {
-			fmt.Fprint(w, ev)
+			_, _ = fmt.Fprint(w, ev)
 			flusher.Flush()
 		}
 		// Keep connection open until client disconnects.
@@ -149,12 +149,12 @@ func TestSSEClientReconnectsOnServerClose(t *testing.T) {
 		}
 		// First connection: send one event then close.
 		if count == 1 {
-			fmt.Fprint(w, "event: debate:started\nid: 1\ndata: {\"id\":1,\"type\":\"debate:started\"}\n\n")
+			_, _ = fmt.Fprint(w, "event: debate:started\nid: 1\ndata: {\"id\":1,\"type\":\"debate:started\"}\n\n")
 			flusher.Flush()
 			return // close connection
 		}
 		// Second connection: send another event then hold open.
-		fmt.Fprint(w, "event: debate:updated\nid: 2\ndata: {\"id\":2,\"type\":\"debate:updated\"}\n\n")
+		_, _ = fmt.Fprint(w, "event: debate:updated\nid: 2\ndata: {\"id\":2,\"type\":\"debate:updated\"}\n\n")
 		flusher.Flush()
 		<-r.Context().Done()
 	}))
@@ -211,12 +211,12 @@ func TestSSEClientSendsLastEventID(t *testing.T) {
 		}
 
 		if count == 1 {
-			fmt.Fprint(w, "event: debate:started\nid: 42\ndata: {\"id\":42,\"type\":\"debate:started\"}\n\n")
+			_, _ = fmt.Fprint(w, "event: debate:started\nid: 42\ndata: {\"id\":42,\"type\":\"debate:started\"}\n\n")
 			flusher.Flush()
 			return // close to trigger reconnect
 		}
 
-		fmt.Fprint(w, "event: debate:updated\nid: 43\ndata: {\"id\":43,\"type\":\"debate:updated\"}\n\n")
+		_, _ = fmt.Fprint(w, "event: debate:updated\nid: 43\ndata: {\"id\":43,\"type\":\"debate:updated\"}\n\n")
 		flusher.Flush()
 		<-r.Context().Done()
 	}))

--- a/monitor/internal/tui/views/pairs_viewmodel.go
+++ b/monitor/internal/tui/views/pairs_viewmodel.go
@@ -200,10 +200,10 @@ func (vm *PairsViewModel) applyFilter() {
 		if ws != "" && p.Workspace != ws {
 			continue
 		}
-		if q != "" && !(strings.Contains(strings.ToLower(p.Name), q) ||
-			strings.Contains(strings.ToLower(p.Component), q) ||
-			strings.Contains(strings.ToLower(p.Phase), q) ||
-			strings.Contains(strings.ToLower(p.Status), q)) {
+		if q != "" && !strings.Contains(strings.ToLower(p.Name), q) &&
+			!strings.Contains(strings.ToLower(p.Component), q) &&
+			!strings.Contains(strings.ToLower(p.Phase), q) &&
+			!strings.Contains(strings.ToLower(p.Status), q) {
 			continue
 		}
 		vm.filtered = append(vm.filtered, p)

--- a/monitor/internal/watcher/debounce.go
+++ b/monitor/internal/watcher/debounce.go
@@ -52,7 +52,7 @@ func NewWithOptions(dir string, opts ...Option) (*Watcher, error) {
 		return nil
 	})
 	if err != nil {
-		fsw.Close()
+		_ = fsw.Close()
 		return nil, fmt.Errorf("walk directory %q: %w", dir, err)
 	}
 

--- a/monitor/internal/watcher/debounce_test.go
+++ b/monitor/internal/watcher/debounce_test.go
@@ -22,7 +22,7 @@ func TestNewWithOptions_Debounce_RapidWritesSameFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create watcher: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	go w.Run(t.Context())
 	time.Sleep(50 * time.Millisecond)
@@ -71,7 +71,7 @@ func TestNewWithOptions_Debounce_DifferentFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create watcher: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	go w.Run(t.Context())
 	time.Sleep(50 * time.Millisecond)
@@ -117,7 +117,7 @@ func TestNewWithOptions_DebounceConfigurable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create watcher: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	go w.Run(t.Context())
 	time.Sleep(50 * time.Millisecond)

--- a/monitor/internal/watcher/watcher_harden_test.go
+++ b/monitor/internal/watcher/watcher_harden_test.go
@@ -86,7 +86,7 @@ func TestWatcher_RunCalledTwice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	ctx, cancel := context.WithCancel(t.Context())
 
@@ -123,7 +123,7 @@ func TestWatcher_WatchedDirDeleted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -148,7 +148,7 @@ func TestWatcher_NewSubdirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	go w.Run(t.Context())
 	time.Sleep(50 * time.Millisecond)
@@ -196,7 +196,7 @@ func TestWatcher_SymlinkDirectorySkipped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -239,7 +239,7 @@ func TestWatcher_EventIDsAreUnique(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	go w.Run(t.Context())
 	time.Sleep(50 * time.Millisecond)
@@ -305,5 +305,5 @@ func TestWatcher_ChannelClosedAfterRun(t *testing.T) {
 		t.Fatal("events channel not closed after Run returned")
 	}
 
-	w.Close()
+	_ = w.Close()
 }

--- a/monitor/internal/watcher/watcher_test.go
+++ b/monitor/internal/watcher/watcher_test.go
@@ -33,7 +33,7 @@ func TestWatcher_FileCreated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create watcher: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	go w.Run(t.Context())
 
@@ -64,7 +64,7 @@ func TestWatcher_FileModified(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create watcher: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	go w.Run(t.Context())
 
@@ -94,7 +94,7 @@ func TestWatcher_FileDeleted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create watcher: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	go w.Run(t.Context())
 


### PR DESCRIPTION
## Summary

- Add `monitor/.golangci.yml` (v2 format) with errcheck, staticcheck, govet enabled
- Fix last remaining errcheck: `cmd/monitor/main.go` watcher Close() in defer
- Integrates all 3 prerequisite lint-fix branches (PR 165, 166, 167)
- `golangci-lint run ./...` now reports 0 issues

## Milestone

M1: Lint compliance (final issue) — part of ratchet monitor quality improvements epic

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes  
- [x] `golangci-lint run ./...` reports 0 issues