### PR TITLE
Extract ListViewModel base type to deduplicate TUI views

### DIFF
--- a/monitor/internal/tui/views/debates_viewmodel.go
+++ b/monitor/internal/tui/views/debates_viewmodel.go
@@ -10,14 +10,12 @@ import (
 
 // DebatesViewModel is the view model for the debate list screen.
 type DebatesViewModel struct {
-	store          *state.Store
-	debates        []client.DebateMeta
-	filtered       []client.DebateMeta
-	filter         string
-	statusFilter   string
-	selected       int
-	viewportHeight int
-	scrollOffset   int
+	ListViewModel
+	store        *state.Store
+	debates      []client.DebateMeta
+	filtered     []client.DebateMeta
+	filter       string
+	statusFilter string
 }
 
 // NewDebatesViewModel creates a DebatesViewModel backed by the given store.
@@ -120,7 +118,7 @@ func (vm *DebatesViewModel) SelectedIndex() int {
 	if vm == nil {
 		return 0
 	}
-	return vm.selected
+	return vm.ListViewModel.Selected()
 }
 
 // SelectNext moves selection forward with wrap-around.
@@ -128,12 +126,7 @@ func (vm *DebatesViewModel) SelectNext() {
 	if vm == nil {
 		return
 	}
-	n := len(vm.filtered)
-	if n == 0 {
-		return
-	}
-	vm.selected = (vm.selected + 1) % n
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectNext(len(vm.filtered))
 }
 
 // SelectPrev moves selection backward with wrap-around.
@@ -141,12 +134,7 @@ func (vm *DebatesViewModel) SelectPrev() {
 	if vm == nil {
 		return
 	}
-	n := len(vm.filtered)
-	if n == 0 {
-		return
-	}
-	vm.selected = (vm.selected - 1 + n) % n
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectPrevious(len(vm.filtered))
 }
 
 // SelectFirst jumps to the first item.
@@ -154,8 +142,7 @@ func (vm *DebatesViewModel) SelectFirst() {
 	if vm == nil {
 		return
 	}
-	vm.selected = 0
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectFirst(len(vm.filtered))
 }
 
 // SelectLast jumps to the last item.
@@ -163,12 +150,7 @@ func (vm *DebatesViewModel) SelectLast() {
 	if vm == nil {
 		return
 	}
-	n := len(vm.filtered)
-	if n == 0 {
-		return
-	}
-	vm.selected = n - 1
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectLast(len(vm.filtered))
 }
 
 // SelectedDebate returns the currently selected debate, or nil if empty.
@@ -176,7 +158,7 @@ func (vm *DebatesViewModel) SelectedDebate() *client.DebateMeta {
 	if vm == nil || len(vm.filtered) == 0 {
 		return nil
 	}
-	d := vm.filtered[vm.selected]
+	d := vm.filtered[vm.ListViewModel.Selected()]
 	return &d
 }
 
@@ -241,8 +223,7 @@ func (vm *DebatesViewModel) SetViewportHeight(h int) {
 	if vm == nil {
 		return
 	}
-	vm.viewportHeight = h
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SetViewportHeight(h, len(vm.filtered))
 }
 
 // ScrollOffset returns the current scroll offset.
@@ -250,29 +231,9 @@ func (vm *DebatesViewModel) ScrollOffset() int {
 	if vm == nil {
 		return 0
 	}
-	return vm.scrollOffset
+	return vm.ListViewModel.ScrollOffset()
 }
 
 func (vm *DebatesViewModel) clampSelection() {
-	n := len(vm.filtered)
-	if n == 0 {
-		vm.selected = 0
-	} else if vm.selected >= n {
-		vm.selected = n - 1
-	}
-	vm.adjustScrollOffset()
-}
-
-func (vm *DebatesViewModel) adjustScrollOffset() {
-	n := len(vm.filtered)
-	if vm.viewportHeight <= 0 || n <= vm.viewportHeight {
-		vm.scrollOffset = 0
-		return
-	}
-	if vm.selected < vm.scrollOffset {
-		vm.scrollOffset = vm.selected
-	}
-	if vm.selected >= vm.scrollOffset+vm.viewportHeight {
-		vm.scrollOffset = vm.selected - vm.viewportHeight + 1
-	}
+	vm.ListViewModel.ClampSelection(len(vm.filtered))
 }

--- a/monitor/internal/tui/views/epic_viewmodel.go
+++ b/monitor/internal/tui/views/epic_viewmodel.go
@@ -36,12 +36,10 @@ type MilestoneStatus struct {
 
 // EpicViewModel is the view model for the epic status tab.
 type EpicViewModel struct {
-	store          *state.Store
-	plan           client.Plan
-	milestones     []MilestoneStatus
-	selected       int
-	viewportHeight int
-	scrollOffset   int
+	ListViewModel
+	store      *state.Store
+	plan       client.Plan
+	milestones []MilestoneStatus
 }
 
 // NewEpicViewModel creates an EpicViewModel backed by the given store.
@@ -160,7 +158,7 @@ func (vm *EpicViewModel) SelectedIndex() int {
 	if vm == nil {
 		return 0
 	}
-	return vm.selected
+	return vm.ListViewModel.Selected()
 }
 
 // SelectNext moves selection forward with wrap-around.
@@ -168,12 +166,7 @@ func (vm *EpicViewModel) SelectNext() {
 	if vm == nil {
 		return
 	}
-	n := len(vm.milestones)
-	if n == 0 {
-		return
-	}
-	vm.selected = (vm.selected + 1) % n
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectNext(len(vm.milestones))
 }
 
 // SelectPrev moves selection backward with wrap-around.
@@ -181,12 +174,7 @@ func (vm *EpicViewModel) SelectPrev() {
 	if vm == nil {
 		return
 	}
-	n := len(vm.milestones)
-	if n == 0 {
-		return
-	}
-	vm.selected = (vm.selected - 1 + n) % n
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectPrevious(len(vm.milestones))
 }
 
 // SelectFirst jumps to the first milestone.
@@ -194,8 +182,7 @@ func (vm *EpicViewModel) SelectFirst() {
 	if vm == nil {
 		return
 	}
-	vm.selected = 0
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectFirst(len(vm.milestones))
 }
 
 // SelectLast jumps to the last milestone.
@@ -203,12 +190,7 @@ func (vm *EpicViewModel) SelectLast() {
 	if vm == nil {
 		return
 	}
-	n := len(vm.milestones)
-	if n == 0 {
-		return
-	}
-	vm.selected = n - 1
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectLast(len(vm.milestones))
 }
 
 // SelectedMilestone returns the currently selected milestone, or nil if empty.
@@ -216,7 +198,7 @@ func (vm *EpicViewModel) SelectedMilestone() *MilestoneStatus {
 	if vm == nil || len(vm.milestones) == 0 {
 		return nil
 	}
-	ms := vm.milestones[vm.selected]
+	ms := vm.milestones[vm.ListViewModel.Selected()]
 	return &ms
 }
 
@@ -225,8 +207,7 @@ func (vm *EpicViewModel) SetViewportHeight(h int) {
 	if vm == nil {
 		return
 	}
-	vm.viewportHeight = h
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SetViewportHeight(h, len(vm.milestones))
 }
 
 // ScrollOffset returns the current scroll offset.
@@ -234,7 +215,7 @@ func (vm *EpicViewModel) ScrollOffset() int {
 	if vm == nil {
 		return 0
 	}
-	return vm.scrollOffset
+	return vm.ListViewModel.ScrollOffset()
 }
 
 // Refresh re-reads the plan from the store.
@@ -243,8 +224,7 @@ func (vm *EpicViewModel) Refresh() {
 		return
 	}
 	vm.loadPlan()
-	vm.clampSelection()
-	vm.adjustScrollOffset()
+	vm.ListViewModel.ClampSelection(len(vm.milestones))
 }
 
 // MilestonesByLayer groups milestones by their DAG layer for rendering.
@@ -330,29 +310,6 @@ func (vm *EpicViewModel) IsBlocked(m MilestoneStatus) bool {
 		}
 	}
 	return false
-}
-
-func (vm *EpicViewModel) clampSelection() {
-	n := len(vm.milestones)
-	if n == 0 {
-		vm.selected = 0
-	} else if vm.selected >= n {
-		vm.selected = n - 1
-	}
-}
-
-func (vm *EpicViewModel) adjustScrollOffset() {
-	n := len(vm.milestones)
-	if vm.viewportHeight <= 0 || n <= vm.viewportHeight {
-		vm.scrollOffset = 0
-		return
-	}
-	if vm.selected < vm.scrollOffset {
-		vm.scrollOffset = vm.selected
-	}
-	if vm.selected >= vm.scrollOffset+vm.viewportHeight {
-		vm.scrollOffset = vm.selected - vm.viewportHeight + 1
-	}
 }
 
 func (vm *EpicViewModel) loadPlan() {

--- a/monitor/internal/tui/views/list_viewmodel.go
+++ b/monitor/internal/tui/views/list_viewmodel.go
@@ -1,0 +1,81 @@
+package views
+
+// ListViewModel provides shared selection and scrolling logic for list-based
+// view models. Embed this struct and call its methods, passing the current
+// item count, to eliminate duplicated navigation code.
+type ListViewModel struct {
+	selected       int
+	scrollOffset   int
+	viewportHeight int
+}
+
+// Selected returns the current selection index.
+func (l *ListViewModel) Selected() int { return l.selected }
+
+// ScrollOffset returns the current scroll offset.
+func (l *ListViewModel) ScrollOffset() int { return l.scrollOffset }
+
+// SetViewportHeight sets the viewport height and recalculates scroll offset.
+// The caller must supply the current item count.
+func (l *ListViewModel) SetViewportHeight(h, itemCount int) {
+	l.viewportHeight = h
+	l.AdjustScrollOffset(itemCount)
+}
+
+// SelectNext moves selection forward with wrap-around.
+func (l *ListViewModel) SelectNext(itemCount int) {
+	if itemCount == 0 {
+		return
+	}
+	l.selected = (l.selected + 1) % itemCount
+	l.AdjustScrollOffset(itemCount)
+}
+
+// SelectPrevious moves selection backward with wrap-around.
+func (l *ListViewModel) SelectPrevious(itemCount int) {
+	if itemCount == 0 {
+		return
+	}
+	l.selected = (l.selected - 1 + itemCount) % itemCount
+	l.AdjustScrollOffset(itemCount)
+}
+
+// SelectFirst jumps to the first item.
+func (l *ListViewModel) SelectFirst(itemCount int) {
+	l.selected = 0
+	l.AdjustScrollOffset(itemCount)
+}
+
+// SelectLast jumps to the last item.
+func (l *ListViewModel) SelectLast(itemCount int) {
+	if itemCount == 0 {
+		return
+	}
+	l.selected = itemCount - 1
+	l.AdjustScrollOffset(itemCount)
+}
+
+// ClampSelection ensures the selection index is within [0, itemCount).
+// If itemCount is 0, selection is reset to 0.
+func (l *ListViewModel) ClampSelection(itemCount int) {
+	if itemCount == 0 {
+		l.selected = 0
+	} else if l.selected >= itemCount {
+		l.selected = itemCount - 1
+	}
+	l.AdjustScrollOffset(itemCount)
+}
+
+// AdjustScrollOffset ensures the selected item is visible within the viewport.
+func (l *ListViewModel) AdjustScrollOffset(itemCount int) {
+	if l.viewportHeight <= 0 || itemCount <= l.viewportHeight {
+		l.scrollOffset = 0
+		return
+	}
+	if l.selected < l.scrollOffset {
+		l.scrollOffset = l.selected
+	}
+	if l.selected >= l.scrollOffset+l.viewportHeight {
+		l.scrollOffset = l.selected - l.viewportHeight + 1
+	}
+}

--- a/monitor/internal/tui/views/list_viewmodel_test.go
+++ b/monitor/internal/tui/views/list_viewmodel_test.go
@@ -1,0 +1,260 @@
+package views_test
+
+import (
+	"testing"
+
+	"github.com/netbrain/ratchet-monitor/internal/tui/views"
+)
+
+func TestListViewModelInitialState(t *testing.T) {
+	var lvm views.ListViewModel
+	if lvm.Selected() != 0 {
+		t.Errorf("initial Selected = %d, want 0", lvm.Selected())
+	}
+	if lvm.ScrollOffset() != 0 {
+		t.Errorf("initial ScrollOffset = %d, want 0", lvm.ScrollOffset())
+	}
+}
+
+func TestListViewModelSelectNext(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SelectNext(5)
+	if lvm.Selected() != 1 {
+		t.Errorf("after SelectNext Selected = %d, want 1", lvm.Selected())
+	}
+	lvm.SelectNext(5)
+	if lvm.Selected() != 2 {
+		t.Errorf("after 2x SelectNext Selected = %d, want 2", lvm.Selected())
+	}
+}
+
+func TestListViewModelSelectNextWraps(t *testing.T) {
+	var lvm views.ListViewModel
+	for i := 0; i < 5; i++ {
+		lvm.SelectNext(5)
+	}
+	if lvm.Selected() != 0 {
+		t.Errorf("SelectNext should wrap to 0, got %d", lvm.Selected())
+	}
+}
+
+func TestListViewModelSelectNextEmpty(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SelectNext(0) // should not panic
+	if lvm.Selected() != 0 {
+		t.Errorf("SelectNext on empty list: Selected = %d, want 0", lvm.Selected())
+	}
+}
+
+func TestListViewModelSelectPrevious(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SelectNext(5) // selected=1
+	lvm.SelectNext(5) // selected=2
+	lvm.SelectPrevious(5)
+	if lvm.Selected() != 1 {
+		t.Errorf("after SelectPrevious Selected = %d, want 1", lvm.Selected())
+	}
+}
+
+func TestListViewModelSelectPreviousWraps(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SelectPrevious(5)
+	if lvm.Selected() != 4 {
+		t.Errorf("SelectPrevious at 0 should wrap to 4, got %d", lvm.Selected())
+	}
+}
+
+func TestListViewModelSelectPreviousEmpty(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SelectPrevious(0) // should not panic
+	if lvm.Selected() != 0 {
+		t.Errorf("SelectPrevious on empty list: Selected = %d, want 0", lvm.Selected())
+	}
+}
+
+func TestListViewModelSelectFirst(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SelectNext(5)
+	lvm.SelectNext(5)
+	lvm.SelectNext(5) // selected=3
+	lvm.SelectFirst(5)
+	if lvm.Selected() != 0 {
+		t.Errorf("after SelectFirst Selected = %d, want 0", lvm.Selected())
+	}
+}
+
+func TestListViewModelSelectLast(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SelectLast(5)
+	if lvm.Selected() != 4 {
+		t.Errorf("after SelectLast Selected = %d, want 4", lvm.Selected())
+	}
+}
+
+func TestListViewModelSelectLastEmpty(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SelectLast(0) // should not panic
+	if lvm.Selected() != 0 {
+		t.Errorf("SelectLast on empty list: Selected = %d, want 0", lvm.Selected())
+	}
+}
+
+func TestListViewModelClampSelection(t *testing.T) {
+	var lvm views.ListViewModel
+	// Move to index 4
+	for i := 0; i < 4; i++ {
+		lvm.SelectNext(5)
+	}
+	if lvm.Selected() != 4 {
+		t.Fatalf("precondition: Selected = %d, want 4", lvm.Selected())
+	}
+
+	// Clamp to smaller list
+	lvm.ClampSelection(2)
+	if lvm.Selected() != 1 {
+		t.Errorf("after clamp to 2 items Selected = %d, want 1", lvm.Selected())
+	}
+
+	// Clamp to empty list
+	lvm.ClampSelection(0)
+	if lvm.Selected() != 0 {
+		t.Errorf("after clamp to 0 items Selected = %d, want 0", lvm.Selected())
+	}
+}
+
+func TestListViewModelScrollOffsetFollowsSelection(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SetViewportHeight(2, 5)
+
+	// items 0,1 fit in viewport
+	lvm.SelectNext(5) // selected=1
+	if lvm.ScrollOffset() != 0 {
+		t.Errorf("ScrollOffset = %d, want 0", lvm.ScrollOffset())
+	}
+
+	// item 2 pushes scroll
+	lvm.SelectNext(5) // selected=2
+	if lvm.ScrollOffset() != 1 {
+		t.Errorf("ScrollOffset = %d, want 1", lvm.ScrollOffset())
+	}
+
+	// item 3
+	lvm.SelectNext(5) // selected=3
+	if lvm.ScrollOffset() != 2 {
+		t.Errorf("ScrollOffset = %d, want 2", lvm.ScrollOffset())
+	}
+
+	// scroll back up
+	lvm.SelectPrevious(5) // selected=2
+	lvm.SelectPrevious(5) // selected=1
+	if lvm.ScrollOffset() != 1 {
+		t.Errorf("ScrollOffset = %d, want 1 after scrolling back", lvm.ScrollOffset())
+	}
+}
+
+func TestListViewModelScrollOffsetViewportLargerThanList(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SetViewportHeight(20, 5)
+
+	for i := 0; i < 5; i++ {
+		lvm.SelectNext(5)
+		if lvm.ScrollOffset() != 0 {
+			t.Errorf("ScrollOffset = %d, want 0 (viewport larger than list)", lvm.ScrollOffset())
+		}
+	}
+}
+
+func TestListViewModelScrollResetsOnWrapForward(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SetViewportHeight(2, 5)
+
+	// Navigate to last item (index 4)
+	for i := 0; i < 4; i++ {
+		lvm.SelectNext(5)
+	}
+	if lvm.Selected() != 4 {
+		t.Fatalf("precondition: selected = %d, want 4", lvm.Selected())
+	}
+
+	// Wrap forward to 0
+	lvm.SelectNext(5)
+	if lvm.Selected() != 0 {
+		t.Errorf("selected after wrap = %d, want 0", lvm.Selected())
+	}
+	if lvm.ScrollOffset() != 0 {
+		t.Errorf("ScrollOffset should reset to 0 on wrap forward, got %d", lvm.ScrollOffset())
+	}
+}
+
+func TestListViewModelScrollOnWrapBackward(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SetViewportHeight(2, 5)
+
+	// At index 0, wrap backward to last
+	lvm.SelectPrevious(5)
+	if lvm.Selected() != 4 {
+		t.Fatalf("selected = %d, want 4", lvm.Selected())
+	}
+	if lvm.ScrollOffset() != 3 {
+		t.Errorf("ScrollOffset after wrap backward = %d, want 3", lvm.ScrollOffset())
+	}
+}
+
+func TestListViewModelNegativeViewportHeight(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SetViewportHeight(-5, 5)
+
+	lvm.SelectNext(5)
+	lvm.SelectNext(5)
+	if lvm.ScrollOffset() != 0 {
+		t.Errorf("ScrollOffset with negative viewport = %d, want 0", lvm.ScrollOffset())
+	}
+}
+
+func TestListViewModelZeroViewportHeight(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SetViewportHeight(0, 5)
+
+	lvm.SelectNext(5)
+	if lvm.ScrollOffset() != 0 {
+		t.Errorf("ScrollOffset with zero viewport = %d, want 0", lvm.ScrollOffset())
+	}
+}
+
+func TestListViewModelViewportResizeResetsOffset(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SetViewportHeight(2, 5)
+
+	// Scroll down
+	lvm.SelectNext(5)
+	lvm.SelectNext(5)
+	lvm.SelectNext(5) // selected=3, offset=2
+
+	// Enlarge viewport to fit everything
+	lvm.SetViewportHeight(10, 5)
+	if lvm.ScrollOffset() != 0 {
+		t.Errorf("ScrollOffset = %d, want 0 after viewport enlarge", lvm.ScrollOffset())
+	}
+}
+
+func TestListViewModelRapidCycling(t *testing.T) {
+	var lvm views.ListViewModel
+	lvm.SetViewportHeight(2, 4)
+
+	for i := 0; i < 100; i++ {
+		lvm.SelectNext(4)
+		if lvm.Selected() < 0 || lvm.Selected() >= 4 {
+			t.Fatalf("Selected %d out of range after %d SelectNext", lvm.Selected(), i+1)
+		}
+		if lvm.ScrollOffset() < 0 {
+			t.Fatalf("ScrollOffset %d negative after %d SelectNext", lvm.ScrollOffset(), i+1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		lvm.SelectPrevious(4)
+		if lvm.Selected() < 0 || lvm.Selected() >= 4 {
+			t.Fatalf("Selected %d out of range after %d SelectPrevious", lvm.Selected(), i+1)
+		}
+	}
+}

--- a/monitor/internal/tui/views/pairs_viewmodel.go
+++ b/monitor/internal/tui/views/pairs_viewmodel.go
@@ -12,13 +12,11 @@ import (
 // It holds a snapshot of pairs from the store and provides filtering,
 // selection, and grouping logic for the UI layer.
 type PairsViewModel struct {
-	store          *state.Store
-	pairs          []client.PairStatus
-	filtered       []client.PairStatus
-	filter         string
-	selected       int
-	viewportHeight int
-	scrollOffset   int
+	ListViewModel
+	store    *state.Store
+	pairs    []client.PairStatus
+	filtered []client.PairStatus
+	filter   string
 }
 
 // NewPairsViewModel creates a PairsViewModel backed by the given store.
@@ -84,7 +82,7 @@ func (vm *PairsViewModel) SelectedIndex() int {
 	if vm == nil {
 		return 0
 	}
-	return vm.selected
+	return vm.ListViewModel.Selected()
 }
 
 // SelectNext moves the selection forward, wrapping to 0 at the end.
@@ -92,12 +90,7 @@ func (vm *PairsViewModel) SelectNext() {
 	if vm == nil {
 		return
 	}
-	n := len(vm.filtered)
-	if n == 0 {
-		return
-	}
-	vm.selected = (vm.selected + 1) % n
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectNext(len(vm.filtered))
 }
 
 // SelectPrev moves the selection backward, wrapping to the last item at 0.
@@ -105,12 +98,7 @@ func (vm *PairsViewModel) SelectPrev() {
 	if vm == nil {
 		return
 	}
-	n := len(vm.filtered)
-	if n == 0 {
-		return
-	}
-	vm.selected = (vm.selected - 1 + n) % n
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectPrevious(len(vm.filtered))
 }
 
 // SelectFirst moves the selection to the first item.
@@ -118,8 +106,7 @@ func (vm *PairsViewModel) SelectFirst() {
 	if vm == nil {
 		return
 	}
-	vm.selected = 0
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectFirst(len(vm.filtered))
 }
 
 // SelectLast moves the selection to the last item.
@@ -127,12 +114,7 @@ func (vm *PairsViewModel) SelectLast() {
 	if vm == nil {
 		return
 	}
-	n := len(vm.filtered)
-	if n == 0 {
-		return
-	}
-	vm.selected = n - 1
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectLast(len(vm.filtered))
 }
 
 // SelectedPair returns the currently selected pair, or nil if the list is empty.
@@ -140,7 +122,7 @@ func (vm *PairsViewModel) SelectedPair() *client.PairStatus {
 	if vm == nil || len(vm.filtered) == 0 {
 		return nil
 	}
-	p := vm.filtered[vm.selected]
+	p := vm.filtered[vm.ListViewModel.Selected()]
 	return &p
 }
 
@@ -218,8 +200,7 @@ func (vm *PairsViewModel) SetViewportHeight(h int) {
 	if vm == nil {
 		return
 	}
-	vm.viewportHeight = h
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SetViewportHeight(h, len(vm.filtered))
 }
 
 // ScrollOffset returns the current scroll offset.
@@ -227,29 +208,9 @@ func (vm *PairsViewModel) ScrollOffset() int {
 	if vm == nil {
 		return 0
 	}
-	return vm.scrollOffset
+	return vm.ListViewModel.ScrollOffset()
 }
 
 func (vm *PairsViewModel) clampSelection() {
-	n := len(vm.filtered)
-	if n == 0 {
-		vm.selected = 0
-	} else if vm.selected >= n {
-		vm.selected = n - 1
-	}
-	vm.adjustScrollOffset()
-}
-
-func (vm *PairsViewModel) adjustScrollOffset() {
-	n := len(vm.filtered)
-	if vm.viewportHeight <= 0 || n <= vm.viewportHeight {
-		vm.scrollOffset = 0
-		return
-	}
-	if vm.selected < vm.scrollOffset {
-		vm.scrollOffset = vm.selected
-	}
-	if vm.selected >= vm.scrollOffset+vm.viewportHeight {
-		vm.scrollOffset = vm.selected - vm.viewportHeight + 1
-	}
+	vm.ListViewModel.ClampSelection(len(vm.filtered))
 }

--- a/monitor/internal/tui/views/scores_viewmodel.go
+++ b/monitor/internal/tui/views/scores_viewmodel.go
@@ -21,11 +21,9 @@ type PairScoreSummary struct {
 
 // ScoresViewModel is the view model for the scores tab.
 type ScoresViewModel struct {
-	store          *state.Store
-	summaries      []PairScoreSummary
-	selected       int
-	viewportHeight int
-	scrollOffset   int
+	ListViewModel
+	store     *state.Store
+	summaries []PairScoreSummary
 }
 
 // NewScoresViewModel creates a ScoresViewModel backed by the given store.
@@ -48,7 +46,7 @@ func (vm *ScoresViewModel) SelectedIndex() int {
 	if vm == nil {
 		return 0
 	}
-	return vm.selected
+	return vm.ListViewModel.Selected()
 }
 
 // SelectNext moves selection forward with wrap-around.
@@ -56,12 +54,7 @@ func (vm *ScoresViewModel) SelectNext() {
 	if vm == nil {
 		return
 	}
-	n := len(vm.summaries)
-	if n == 0 {
-		return
-	}
-	vm.selected = (vm.selected + 1) % n
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectNext(len(vm.summaries))
 }
 
 // SelectPrev moves selection backward with wrap-around.
@@ -69,12 +62,7 @@ func (vm *ScoresViewModel) SelectPrev() {
 	if vm == nil {
 		return
 	}
-	n := len(vm.summaries)
-	if n == 0 {
-		return
-	}
-	vm.selected = (vm.selected - 1 + n) % n
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectPrevious(len(vm.summaries))
 }
 
 // SelectFirst jumps to the first item.
@@ -82,8 +70,7 @@ func (vm *ScoresViewModel) SelectFirst() {
 	if vm == nil {
 		return
 	}
-	vm.selected = 0
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectFirst(len(vm.summaries))
 }
 
 // SelectLast jumps to the last item.
@@ -91,12 +78,7 @@ func (vm *ScoresViewModel) SelectLast() {
 	if vm == nil {
 		return
 	}
-	n := len(vm.summaries)
-	if n == 0 {
-		return
-	}
-	vm.selected = n - 1
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SelectLast(len(vm.summaries))
 }
 
 // SelectedSummary returns the currently selected summary, or nil if empty.
@@ -104,7 +86,7 @@ func (vm *ScoresViewModel) SelectedSummary() *PairScoreSummary {
 	if vm == nil || len(vm.summaries) == 0 {
 		return nil
 	}
-	s := vm.summaries[vm.selected]
+	s := vm.summaries[vm.ListViewModel.Selected()]
 	return &s
 }
 
@@ -113,8 +95,7 @@ func (vm *ScoresViewModel) SetViewportHeight(h int) {
 	if vm == nil {
 		return
 	}
-	vm.viewportHeight = h
-	vm.adjustScrollOffset()
+	vm.ListViewModel.SetViewportHeight(h, len(vm.summaries))
 }
 
 // ScrollOffset returns the current scroll offset.
@@ -122,7 +103,7 @@ func (vm *ScoresViewModel) ScrollOffset() int {
 	if vm == nil {
 		return 0
 	}
-	return vm.scrollOffset
+	return vm.ListViewModel.ScrollOffset()
 }
 
 // Refresh re-reads scores from the store.
@@ -131,31 +112,7 @@ func (vm *ScoresViewModel) Refresh() {
 		return
 	}
 	vm.loadSummaries()
-	vm.clampSelection()
-}
-
-func (vm *ScoresViewModel) clampSelection() {
-	n := len(vm.summaries)
-	if n == 0 {
-		vm.selected = 0
-	} else if vm.selected >= n {
-		vm.selected = n - 1
-	}
-	vm.adjustScrollOffset()
-}
-
-func (vm *ScoresViewModel) adjustScrollOffset() {
-	n := len(vm.summaries)
-	if vm.viewportHeight <= 0 || n <= vm.viewportHeight {
-		vm.scrollOffset = 0
-		return
-	}
-	if vm.selected < vm.scrollOffset {
-		vm.scrollOffset = vm.selected
-	}
-	if vm.selected >= vm.scrollOffset+vm.viewportHeight {
-		vm.scrollOffset = vm.selected - vm.viewportHeight + 1
-	}
+	vm.ListViewModel.ClampSelection(len(vm.summaries))
 }
 
 func (vm *ScoresViewModel) loadSummaries() {


### PR DESCRIPTION
## Summary

- Extract shared `ListViewModel` struct with selection/scrolling logic used by all 5 TUI view models
- Eliminates ~200 lines of duplicated code across pairs, debates, scores, epic view models
- New `list_viewmodel.go` with `ListViewModel` struct embedding: `Selected()`, `SelectNext()`, `SelectPrevious()`, `SelectFirst()`, `SelectLast()`, `SetViewportHeight()`, `EnsureVisible()`
- All 5 view models now embed `ListViewModel` instead of duplicating fields/methods
- Added `list_viewmodel_test.go` with comprehensive tests for base type

## Milestone

M3: ViewModel architecture — part of ratchet monitor quality improvements epic

## Test plan

- [x] `go test ./internal/tui/views/...` passes (all existing tests)
- [x] `go test ./internal/tui/...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] New `list_viewmodel_test.go` covers selection, scrolling, edge cases