### PR TITLE
Make SSE ring buffer size configurable via env var

### DIFF
--- a/monitor/cmd/monitor/main.go
+++ b/monitor/cmd/monitor/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -77,7 +78,20 @@ func main() {
 	}
 	defer w.Close()
 
-	broker := sse.NewBroker()
+	var brokerOpts []sse.BrokerOption
+	if v := os.Getenv("RATCHET_RING_BUFFER_SIZE"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			log.Fatalf("invalid RATCHET_RING_BUFFER_SIZE %q: %v", v, err)
+		}
+		if n < sse.MinBufferSize || n > sse.MaxBufferSize {
+			log.Fatalf("RATCHET_RING_BUFFER_SIZE must be between %d and %d, got %d",
+				sse.MinBufferSize, sse.MaxBufferSize, n)
+		}
+		brokerOpts = append(brokerOpts, sse.WithBufferSize(n))
+	}
+
+	broker := sse.NewBroker(brokerOpts...)
 	defer broker.Close()
 
 	// Create the enrichment pipeline instead of a direct watcher->broker pipe.
@@ -138,7 +152,7 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stderr, "watching %s, serving on %s\n", dir, addr)
 	}
-	slog.Info("server starting", "dir", dir, "addr", addr, "workspace", workspace)
+	slog.Info("server starting", "dir", dir, "addr", addr, "workspace", workspace, "ring_buffer_size", broker.BufferSize())
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 		log.Fatalf("server error: %v", err)
 	}

--- a/monitor/internal/sse/broker.go
+++ b/monitor/internal/sse/broker.go
@@ -26,6 +26,33 @@ func (s *Subscription) Unsubscribe() {
 	s.broker.unsubscribe(s)
 }
 
+const (
+	// DefaultBufferSize is the ring buffer capacity when none is specified.
+	DefaultBufferSize = 1024
+	// MinBufferSize is the smallest allowed ring buffer size.
+	MinBufferSize = 64
+	// MaxBufferSize is the largest allowed ring buffer size.
+	MaxBufferSize = 65536
+)
+
+// BrokerOption configures a Broker during construction.
+type BrokerOption func(*Broker)
+
+// WithBufferSize returns a BrokerOption that sets the ring buffer capacity.
+// Values outside [MinBufferSize, MaxBufferSize] are clamped to the nearest bound.
+func WithBufferSize(n int) BrokerOption {
+	return func(b *Broker) {
+		if n < MinBufferSize {
+			n = MinBufferSize
+		}
+		if n > MaxBufferSize {
+			n = MaxBufferSize
+		}
+		b.bufferSize = n
+		b.buffer = make([]events.Event, 0, n)
+	}
+}
+
 // Broker fans out published events to all active subscribers.
 type Broker struct {
 	mu          sync.RWMutex
@@ -36,10 +63,17 @@ type Broker struct {
 }
 
 // NewBroker creates a new Broker ready to accept subscriptions.
-func NewBroker() *Broker {
-	return &Broker{
+// Without options, the broker is created with DefaultBufferSize.
+func NewBroker(opts ...BrokerOption) *Broker {
+	b := &Broker{
 		subscribers: make(map[*Subscription]struct{}),
+		bufferSize:  DefaultBufferSize,
+		buffer:      make([]events.Event, 0, DefaultBufferSize),
 	}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
 }
 
 // Subscribe creates a new Subscription. The returned Subscription
@@ -81,6 +115,13 @@ func (b *Broker) SubscriberCount() int {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	return len(b.subscribers)
+}
+
+// BufferSize returns the current ring buffer capacity.
+func (b *Broker) BufferSize() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.bufferSize
 }
 
 // Publish sends an event to all current subscribers.

--- a/monitor/internal/sse/broker_test.go
+++ b/monitor/internal/sse/broker_test.go
@@ -761,3 +761,129 @@ func TestBroker_SubscribeFromBeyondNewest(t *testing.T) {
 	default:
 	}
 }
+
+// --- Functional option tests ---
+
+func TestNewBroker_DefaultBufferSize(t *testing.T) {
+	b := NewBroker()
+	defer b.Close()
+
+	if got := b.BufferSize(); got != DefaultBufferSize {
+		t.Errorf("default buffer size: got %d, want %d", got, DefaultBufferSize)
+	}
+}
+
+func TestNewBroker_WithBufferSize(t *testing.T) {
+	b := NewBroker(WithBufferSize(256))
+	defer b.Close()
+
+	if got := b.BufferSize(); got != 256 {
+		t.Errorf("buffer size: got %d, want 256", got)
+	}
+}
+
+func TestNewBroker_WithBufferSizeClampMin(t *testing.T) {
+	b := NewBroker(WithBufferSize(1))
+	defer b.Close()
+
+	if got := b.BufferSize(); got != MinBufferSize {
+		t.Errorf("buffer size: got %d, want %d (MinBufferSize)", got, MinBufferSize)
+	}
+}
+
+func TestNewBroker_WithBufferSizeClampMax(t *testing.T) {
+	b := NewBroker(WithBufferSize(999999))
+	defer b.Close()
+
+	if got := b.BufferSize(); got != MaxBufferSize {
+		t.Errorf("buffer size: got %d, want %d (MaxBufferSize)", got, MaxBufferSize)
+	}
+}
+
+func TestNewBroker_WithBufferSizeBoundaries(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"below min", MinBufferSize - 1, MinBufferSize},
+		{"at min", MinBufferSize, MinBufferSize},
+		{"mid range", 512, 512},
+		{"at max", MaxBufferSize, MaxBufferSize},
+		{"above max", MaxBufferSize + 1, MaxBufferSize},
+		{"zero", 0, MinBufferSize},
+		{"negative", -100, MinBufferSize},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBroker(WithBufferSize(tt.in))
+			defer b.Close()
+			if got := b.BufferSize(); got != tt.want {
+				t.Errorf("WithBufferSize(%d): got %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewBroker_WithBufferSizeRingBehavior(t *testing.T) {
+	// Use a small custom buffer and verify eviction works correctly.
+	b := NewBroker(WithBufferSize(64))
+	defer b.Close()
+
+	// Publish more events than the buffer can hold.
+	for i := uint64(1); i <= 100; i++ {
+		b.Publish(events.Event{ID: i, Type: events.FileCreated, Path: "x"})
+	}
+
+	// Buffer should hold events 37..100 (last 64).
+	sub, err := b.SubscribeFrom(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Unsubscribe()
+
+	first := true
+	count := 0
+	for {
+		select {
+		case ev := <-sub.Events():
+			if first {
+				if ev.ID != 37 {
+					t.Errorf("first buffered event ID: got %d, want 37", ev.ID)
+				}
+				first = false
+			}
+			count++
+		default:
+			goto done
+		}
+	}
+done:
+	if count != 64 {
+		t.Errorf("buffered event count: got %d, want 64", count)
+	}
+}
+
+func TestNewBroker_BackwardCompatNoArgs(t *testing.T) {
+	// Verify zero-arg NewBroker still works and produces a functional broker.
+	b := NewBroker()
+	defer b.Close()
+
+	sub, err := b.Subscribe()
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	ev := events.Event{ID: 1, Type: events.FileCreated, Path: "test"}
+	b.Publish(ev)
+
+	select {
+	case got := <-sub.Events():
+		if got.ID != 1 {
+			t.Errorf("event ID: got %d, want 1", got.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `RATCHET_RING_BUFFER_SIZE` env var to configure SSE broker ring buffer capacity
- Default 1024, validated range [64, 65536], fatal on invalid
- Functional option pattern: `NewBroker(WithBufferSize(n))` — fully backward compatible
- 7 new tests covering default size, custom size, clamping, eviction, boundary cases

## Milestone

M5: API enhancements — part of ratchet monitor quality improvements epic

## Test plan

- [x] `go test ./internal/sse/... -v -race` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `NewBroker()` zero-arg backward compatible