### PR TITLE
Fix regression budget warnings to use percentage-based thresholds

### DIFF
--- a/monitor/internal/tui/views/epic_viewmodel.go
+++ b/monitor/internal/tui/views/epic_viewmodel.go
@@ -122,8 +122,12 @@ func (vm *EpicViewModel) RegressionBudgetText(m MilestoneStatus) string {
 	return fmt.Sprintf("%d/%d", m.Regressions, maxReg)
 }
 
-// RegressionWarningLevel returns the warning level for a milestone's regressions.
-// "none" = within budget, "warn" = at or near budget, "danger" = over budget.
+// RegressionWarningLevel returns the warning level for a milestone's regressions
+// based on percentage of budget used:
+//
+//	"none"   = <50% budget used (green)
+//	"warn"   = 50-75% budget used (yellow)
+//	"danger" = >75% budget used (red)
 func (vm *EpicViewModel) RegressionWarningLevel(m MilestoneStatus) string {
 	if vm == nil {
 		return "none"
@@ -132,10 +136,11 @@ func (vm *EpicViewModel) RegressionWarningLevel(m MilestoneStatus) string {
 	if maxReg <= 0 {
 		maxReg = 2 // default budget
 	}
-	if m.Regressions >= maxReg {
+	pct := float64(m.Regressions) / float64(maxReg)
+	if pct > 0.75 {
 		return "danger"
 	}
-	if m.Regressions > 0 && m.Regressions >= maxReg-1 {
+	if pct >= 0.50 {
 		return "warn"
 	}
 	return "none"

--- a/monitor/internal/tui/views/epic_viewmodel_test.go
+++ b/monitor/internal/tui/views/epic_viewmodel_test.go
@@ -861,6 +861,55 @@ func TestRegressionWarningNilReceiver(t *testing.T) {
 	}
 }
 
+// ── Regression percentage boundary tests ─────────────────────────────────
+
+func TestRegressionWarningPercentageBoundaries(t *testing.T) {
+	store := state.NewStore()
+	vm := views.NewEpicViewModel(store)
+
+	tests := []struct {
+		name        string
+		regressions int
+		maxReg      int
+		want        string
+	}{
+		// Green: <50%
+		{"0/4=0%", 0, 4, "none"},
+		{"1/4=25%", 1, 4, "none"},
+		// Yellow: 50%-75% (inclusive lower, inclusive upper)
+		{"2/4=50%", 2, 4, "warn"},
+		{"3/4=75%", 3, 4, "warn"},
+		// Red: >75%
+		{"4/4=100%", 4, 4, "danger"},
+		{"5/4=125%", 5, 4, "danger"},
+		// Edge: exactly 50% with max=2
+		{"1/2=50%", 1, 2, "warn"},
+		// Edge: exactly 75% with larger max
+		{"3/4=75%", 3, 4, "warn"},
+		// Edge: just above 75%
+		{"4/5=80%", 4, 5, "danger"},
+		// Edge: just below 50%
+		{"2/5=40%", 2, 5, "none"},
+		// Zero regressions always green
+		{"0/2=0%", 0, 2, "none"},
+		{"0/10=0%", 0, 10, "none"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := views.MilestoneStatus{
+				Regressions:    tt.regressions,
+				MaxRegressions: tt.maxReg,
+			}
+			got := vm.RegressionWarningLevel(m)
+			if got != tt.want {
+				t.Errorf("RegressionWarningLevel(reg=%d, max=%d) = %q, want %q",
+					tt.regressions, tt.maxReg, got, tt.want)
+			}
+		})
+	}
+}
+
 // ── DAG connectors (Issue 32) ────────────────────────────────────────────
 
 func TestDAGConnectors(t *testing.T) {


### PR DESCRIPTION
## Summary

- Change `RegressionWarningLevel` from absolute thresholds to percentage-based: green <50%, yellow 50-75%, red >75%
- Added 12-case table-driven test covering exact percentage boundaries and edge cases

## Milestone

M4: TUI features — part of ratchet monitor quality improvements epic

## Test plan

- [x] `go test ./internal/tui/views/... -v` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes