### PR TITLE
Add workspace switcher with per-workspace tab memory to TUI

### DIFF
--- a/monitor/internal/tui/app/app.go
+++ b/monitor/internal/tui/app/app.go
@@ -50,13 +50,18 @@ type App struct {
 	cancel    context.CancelFunc
 	once      sync.Once
 	onUpdate  func() // called after store data changes to trigger re-render
+
+	// workspaceTabs remembers the active tab per workspace name so that
+	// switching back to a workspace restores the previously selected tab.
+	workspaceTabs map[string]Tab
 }
 
 // New creates a new App connected to the given server URL.
 func New(serverURL string) *App {
 	a := &App{
-		Store:     state.NewStore(),
-		ActiveTab: TabPairs,
+		Store:         state.NewStore(),
+		ActiveTab:     TabPairs,
+		workspaceTabs: make(map[string]Tab),
 	}
 
 	a.Client = client.NewClient(serverURL,
@@ -281,13 +286,14 @@ func (a *App) StatusLine() string {
 }
 
 // CycleWorkspace switches to the next workspace (wraps around).
-// If no workspaces are configured, this is a no-op.
+// If no workspaces are configured or only one workspace exists, this is a no-op.
+// The current tab is saved for the outgoing workspace and restored for the incoming one.
 func (a *App) CycleWorkspace() {
 	if a.Store == nil {
 		return
 	}
 	workspaces := a.Store.Workspaces()
-	if len(workspaces) == 0 {
+	if len(workspaces) <= 1 {
 		return
 	}
 	current := a.Store.CurrentWorkspace()
@@ -298,8 +304,26 @@ func (a *App) CycleWorkspace() {
 			break
 		}
 	}
-	// Move to next (or first if current not found)
+
+	// Save current tab for the outgoing workspace.
+	if a.workspaceTabs == nil {
+		a.workspaceTabs = make(map[string]Tab)
+	}
+	if current != "" {
+		a.workspaceTabs[current] = a.ActiveTab
+	}
+
+	// Move to next (or first if current not found).
 	next := (idx + 1) % len(workspaces)
-	a.Store.SetCurrentWorkspace(workspaces[next])
+	nextWS := workspaces[next]
+	a.Store.SetCurrentWorkspace(nextWS)
+
+	// Restore tab for the incoming workspace (default to TabPairs).
+	if savedTab, ok := a.workspaceTabs[nextWS]; ok {
+		a.ActiveTab = savedTab
+	} else {
+		a.ActiveTab = TabPairs
+	}
+
 	a.notifyUpdate()
 }

--- a/monitor/internal/tui/app/app_test.go
+++ b/monitor/internal/tui/app/app_test.go
@@ -117,7 +117,7 @@ func TestTabStringUnknown(t *testing.T) {
 
 // TestCycleWorkspacePopulated verifies CycleWorkspace cycles through loaded workspaces.
 func TestCycleWorkspacePopulated(t *testing.T) {
-	a := &App{Store: state.NewStore()}
+	a := &App{Store: state.NewStore(), workspaceTabs: make(map[string]Tab)}
 	a.Store.SetWorkspaces([]string{"frontend", "backend", "infra"})
 	a.Store.SetCurrentWorkspace("frontend")
 
@@ -139,10 +139,76 @@ func TestCycleWorkspacePopulated(t *testing.T) {
 
 // TestCycleWorkspaceEmpty verifies CycleWorkspace is a no-op with no workspaces.
 func TestCycleWorkspaceEmpty(t *testing.T) {
-	a := &App{Store: state.NewStore()}
+	a := &App{Store: state.NewStore(), workspaceTabs: make(map[string]Tab)}
 	a.CycleWorkspace() // must not panic
 	if got := a.Store.CurrentWorkspace(); got != "" {
 		t.Fatalf("expected empty workspace, got %q", got)
+	}
+}
+
+// TestCycleWorkspaceSingleIsNoOp verifies CycleWorkspace is a no-op with only one workspace.
+func TestCycleWorkspaceSingleIsNoOp(t *testing.T) {
+	a := &App{Store: state.NewStore(), workspaceTabs: make(map[string]Tab)}
+	a.Store.SetWorkspaces([]string{"only-one"})
+	a.Store.SetCurrentWorkspace("only-one")
+	a.ActiveTab = TabDebates
+
+	a.CycleWorkspace()
+	if got := a.Store.CurrentWorkspace(); got != "only-one" {
+		t.Fatalf("expected workspace unchanged, got %q", got)
+	}
+	if a.ActiveTab != TabDebates {
+		t.Fatalf("expected tab unchanged, got %v", a.ActiveTab)
+	}
+}
+
+// TestCycleWorkspacePreservesTabPerWorkspace verifies that each workspace
+// remembers its own active tab across switches.
+func TestCycleWorkspacePreservesTabPerWorkspace(t *testing.T) {
+	a := &App{Store: state.NewStore(), ActiveTab: TabDebates, workspaceTabs: make(map[string]Tab)}
+	a.Store.SetWorkspaces([]string{"ws-a", "ws-b"})
+	a.Store.SetCurrentWorkspace("ws-a")
+
+	// ws-a has TabDebates active. Cycle to ws-b.
+	a.CycleWorkspace()
+	if a.Store.CurrentWorkspace() != "ws-b" {
+		t.Fatalf("expected ws-b, got %q", a.Store.CurrentWorkspace())
+	}
+	// ws-b should default to TabPairs (no saved tab).
+	if a.ActiveTab != TabPairs {
+		t.Fatalf("expected TabPairs for new workspace, got %v", a.ActiveTab)
+	}
+
+	// Switch ws-b to TabScores.
+	a.ActiveTab = TabScores
+
+	// Cycle back to ws-a.
+	a.CycleWorkspace()
+	if a.Store.CurrentWorkspace() != "ws-a" {
+		t.Fatalf("expected ws-a, got %q", a.Store.CurrentWorkspace())
+	}
+	// ws-a should remember TabDebates.
+	if a.ActiveTab != TabDebates {
+		t.Fatalf("expected TabDebates restored for ws-a, got %v", a.ActiveTab)
+	}
+
+	// Cycle back to ws-b.
+	a.CycleWorkspace()
+	// ws-b should remember TabScores.
+	if a.ActiveTab != TabScores {
+		t.Fatalf("expected TabScores restored for ws-b, got %v", a.ActiveTab)
+	}
+}
+
+// TestCycleWorkspaceNilMapSafe verifies CycleWorkspace initialises the map if nil.
+func TestCycleWorkspaceNilMapSafe(t *testing.T) {
+	a := &App{Store: state.NewStore()} // workspaceTabs not initialised
+	a.Store.SetWorkspaces([]string{"a", "b"})
+	a.Store.SetCurrentWorkspace("a")
+
+	a.CycleWorkspace() // must not panic
+	if got := a.Store.CurrentWorkspace(); got != "b" {
+		t.Fatalf("expected 'b', got %q", got)
 	}
 }
 

--- a/monitor/internal/tui/components/header.go
+++ b/monitor/internal/tui/components/header.go
@@ -1,15 +1,22 @@
 package components
 
 import (
+	"fmt"
+
 	tui "github.com/grindlemire/go-tui"
 	"github.com/netbrain/ratchet-monitor/internal/tui/client"
 )
 
-// Header renders the top header bar showing the application name and
-// connection state indicator.
-func Header(connState client.ConnectionState) *tui.Element {
+// Header renders the top header bar showing the application name,
+// active workspace (if any), and connection state indicator.
+func Header(connState client.ConnectionState, workspace string) *tui.Element {
+	titleText := "ratchet-monitor"
+	if workspace != "" {
+		titleText = fmt.Sprintf("ratchet-monitor [%s]", workspace)
+	}
+
 	title := tui.New(
-		tui.WithText("ratchet-monitor"),
+		tui.WithText(titleText),
 		tui.WithTextStyle(tui.NewStyle().Bold().Foreground(tui.Cyan)),
 	)
 

--- a/monitor/internal/tui/components/header_test.go
+++ b/monitor/internal/tui/components/header_test.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/netbrain/ratchet-monitor/internal/tui/client"
@@ -8,7 +9,7 @@ import (
 
 // TestHeaderReturnsNonNil verifies that Header returns a valid element (AC-2).
 func TestHeaderReturnsNonNil(t *testing.T) {
-	el := Header(client.Connected)
+	el := Header(client.Connected, "")
 	if el == nil {
 		t.Fatal("Header returned nil")
 	}
@@ -23,7 +24,7 @@ func TestHeaderAcceptsAllConnectionStates(t *testing.T) {
 		client.Reconnecting,
 	}
 	for _, s := range states {
-		el := Header(s)
+		el := Header(s, "")
 		if el == nil {
 			t.Fatalf("Header(%v) returned nil", s)
 		}
@@ -34,11 +35,31 @@ func TestHeaderAcceptsAllConnectionStates(t *testing.T) {
 // text reflecting the connection state. We check the root element or its
 // children for non-empty text.
 func TestHeaderShowsConnectionText(t *testing.T) {
-	el := Header(client.Connected)
+	el := Header(client.Connected, "")
 
 	// The header should contain some text content — either directly
 	// or in children. We just verify the tree is non-trivially populated.
 	if el.Text() == "" && len(el.Children()) == 0 {
 		t.Fatal("Header element has no text and no children — expected connection indicator content")
+	}
+}
+
+// TestHeaderShowsWorkspaceName verifies the header displays the active
+// workspace name in brackets when a workspace is set.
+func TestHeaderShowsWorkspaceName(t *testing.T) {
+	el := Header(client.Connected, "engine")
+	text := collectAllText(el)
+	if !strings.Contains(text, "[engine]") {
+		t.Fatalf("expected header to contain '[engine]', got: %q", text)
+	}
+}
+
+// TestHeaderNoWorkspaceBrackets verifies the header omits workspace brackets
+// when no workspace is set.
+func TestHeaderNoWorkspaceBrackets(t *testing.T) {
+	el := Header(client.Connected, "")
+	text := collectAllText(el)
+	if strings.Contains(text, "[") || strings.Contains(text, "]") {
+		t.Fatalf("expected no brackets in header without workspace, got: %q", text)
 	}
 }

--- a/monitor/internal/tui/components/root.go
+++ b/monitor/internal/tui/components/root.go
@@ -31,12 +31,14 @@ func NewRoot(a *app.App) *Root {
 func (r *Root) Render(tuiApp *tui.App) *tui.Element {
 	var connState client.ConnectionState
 	var statusText string
+	var workspace string
 	if r.app.Store != nil {
 		connState = r.app.Store.ConnectionState()
 		statusText = r.app.StatusLine()
+		workspace = r.app.Store.CurrentWorkspace()
 	}
 
-	header := Header(connState)
+	header := Header(connState, workspace)
 
 	// Stale data banner when disconnected/reconnecting
 	var staleBanner *tui.Element
@@ -83,7 +85,7 @@ func (r *Root) Render(tuiApp *tui.App) *tui.Element {
 		content = Content(r.app.ActiveTab)
 	}
 
-	hints := fmt.Sprintf("1-%d:tab  Tab/S-Tab:cycle  j/k:nav  /:filter  ?:help  q:quit", len(app.AllTabs()))
+	hints := fmt.Sprintf("1-%d:tab  Tab/S-Tab:cycle  w:workspace  j/k:nav  /:filter  ?:help  q:quit", len(app.AllTabs()))
 	statusBar := StatusBar(statusText, hints)
 
 	root := tui.New(

--- a/monitor/internal/tui/components/root_test.go
+++ b/monitor/internal/tui/components/root_test.go
@@ -1,10 +1,13 @@
 package components
 
 import (
+	"strings"
 	"testing"
 
 	tui "github.com/grindlemire/go-tui"
 	"github.com/netbrain/ratchet-monitor/internal/tui/app"
+	"github.com/netbrain/ratchet-monitor/internal/tui/client"
+	"github.com/netbrain/ratchet-monitor/internal/tui/state"
 )
 
 // TestRootImplementsComponent verifies Root satisfies tui.Component.
@@ -275,6 +278,43 @@ func TestRootRenderNilStore(t *testing.T) {
 	children := el.Children()
 	if len(children) < 4 {
 		t.Fatalf("expected at least 4 child zones with nil Store, got %d", len(children))
+	}
+}
+
+// TestRootWorkspaceKeyBinding verifies 'w' key handler exists and cycles workspaces.
+func TestRootWorkspaceKeyBinding(t *testing.T) {
+	store := state.NewStore()
+	store.SetWorkspaces([]string{"ws-a", "ws-b"})
+	store.SetCurrentWorkspace("ws-a")
+	a := &app.App{ActiveTab: app.TabPairs, Store: store}
+	root := NewRoot(a)
+
+	km := root.KeyMap()
+	handler := findRuneHandler(km, 'w')
+	if handler == nil {
+		t.Fatal("no handler found for 'w' key")
+	}
+
+	handler(tui.KeyEvent{Key: tui.KeyRune, Rune: 'w'})
+
+	if got := store.CurrentWorkspace(); got != "ws-b" {
+		t.Fatalf("expected workspace 'ws-b' after pressing 'w', got %q", got)
+	}
+}
+
+// TestRootRenderShowsWorkspaceInHeader verifies the header includes the workspace name.
+func TestRootRenderShowsWorkspaceInHeader(t *testing.T) {
+	store := state.NewStore()
+	store.SetWorkspaces([]string{"engine"})
+	store.SetCurrentWorkspace("engine")
+	store.SetConnectionState(client.Connected)
+	a := &app.App{ActiveTab: app.TabPairs, Store: store}
+	root := NewRoot(a)
+
+	el := root.Render(nil)
+	text := collectAllText(el)
+	if !strings.Contains(text, "[engine]") {
+		t.Fatalf("expected header to contain '[engine]', got: %q", text)
 	}
 }
 

--- a/monitor/internal/tui/state/state_test.go
+++ b/monitor/internal/tui/state/state_test.go
@@ -252,3 +252,64 @@ func TestStoreLastEventID(t *testing.T) {
 		t.Errorf("expected LastEventID '42', got %q", s.LastEventID())
 	}
 }
+
+// ── Workspace state ──────────────────────────────────────────────────────
+
+func TestStoreWorkspaceSetAndGet(t *testing.T) {
+	s := NewStore()
+	if got := s.CurrentWorkspace(); got != "" {
+		t.Fatalf("expected empty initial workspace, got %q", got)
+	}
+
+	s.SetCurrentWorkspace("engine")
+	if got := s.CurrentWorkspace(); got != "engine" {
+		t.Fatalf("expected 'engine', got %q", got)
+	}
+}
+
+func TestStoreWorkspacesListSetAndGet(t *testing.T) {
+	s := NewStore()
+	s.SetWorkspaces([]string{"ws-a", "ws-b", "ws-c"})
+
+	got := s.Workspaces()
+	if len(got) != 3 {
+		t.Fatalf("expected 3 workspaces, got %d", len(got))
+	}
+	if got[0] != "ws-a" || got[1] != "ws-b" || got[2] != "ws-c" {
+		t.Fatalf("unexpected workspace list: %v", got)
+	}
+}
+
+func TestStoreWorkspacesReturnsCopy(t *testing.T) {
+	s := NewStore()
+	s.SetWorkspaces([]string{"a", "b"})
+
+	got := s.Workspaces()
+	got[0] = "mutated"
+
+	if s.Workspaces()[0] == "mutated" {
+		t.Fatal("Workspaces() should return a copy, not the original slice")
+	}
+}
+
+func TestStoreWorkspacesConcurrentAccess(t *testing.T) {
+	s := NewStore()
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			s.SetWorkspaces([]string{"a", "b"})
+			s.SetCurrentWorkspace("a")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			_ = s.Workspaces()
+			_ = s.CurrentWorkspace()
+		}
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

- Header shows active workspace: `ratchet-monitor [engine]`
- `w` key cycles workspaces (no-op when single workspace)
- Per-workspace tab memory — each workspace remembers its active tab
- Status bar shows `w:workspace` hint
- 11 new tests across header, root, state, and app packages

## Milestone

M4: TUI features — part of ratchet monitor quality improvements epic

## Test plan

- [x] `go test ./internal/tui/... -v` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Single workspace = `w` key is no-op
- [x] Tab state persists across workspace switches