### PR TITLE
Add milestone DAG visualization with box-drawing connectors to epic screen

### DIFF
--- a/monitor/internal/tui/components/epic_screen.go
+++ b/monitor/internal/tui/components/epic_screen.go
@@ -111,8 +111,12 @@ func (es *EpicScreen) Render(app *tui.App) *tui.Element {
 
 	// DAG layer summary
 	maxLayer := es.vm.MaxLayer()
+	hasDAG := es.vm.HasDAG()
 	if maxLayer >= 0 {
-		layerText := fmt.Sprintf("Milestone layers: %d (Layer 0 = no dependencies)", maxLayer+1)
+		layerText := fmt.Sprintf("Milestone layers: %d (L0 = no dependencies)", maxLayer+1)
+		if hasDAG {
+			layerText += " — DAG arrows show dependencies"
+		}
 		layerEl := tui.New(
 			tui.WithText(layerText),
 			tui.WithTextStyle(tui.NewStyle().Foreground(tui.ANSIColor(243))),
@@ -160,7 +164,7 @@ func (es *EpicScreen) Render(app *tui.App) *tui.Element {
 			if rowsRendered >= maxRows {
 				break
 			}
-			connectorText := fmt.Sprintf("  │  ── Layer %d ──", m.Layer)
+			connectorText := fmt.Sprintf("  │  ── %s ──", es.vm.DAGLayerLabel(m.Layer))
 			connectorEl := tui.New(
 				tui.WithText(connectorText),
 				tui.WithTextStyle(tui.NewStyle().Foreground(tui.ANSIColor(243))),
@@ -215,7 +219,7 @@ func (es *EpicScreen) buildHeaderRow(cols int) *tui.Element {
 	style := tui.NewStyle().Bold()
 
 	idEl := tui.New(tui.WithText("#"), tui.WithTextStyle(style), tui.WithWidth(4))
-	layerEl := tui.New(tui.WithText("L"), tui.WithTextStyle(style), tui.WithWidth(3))
+	layerEl := tui.New(tui.WithText("L"), tui.WithTextStyle(style), tui.WithWidth(4))
 	nameEl := tui.New(tui.WithText("Milestone"), tui.WithTextStyle(style), tui.WithFlexGrow(1))
 	statusEl := tui.New(tui.WithText("Status"), tui.WithTextStyle(style), tui.WithWidth(14))
 	regEl := tui.New(tui.WithText("Reg"), tui.WithTextStyle(style), tui.WithWidth(8))
@@ -263,11 +267,11 @@ func (es *EpicScreen) buildMilestoneRow(cols, num int, m views.MilestoneStatus, 
 	idEl := tui.New(tui.WithText(fmt.Sprintf("%s%d", dagPrefix, num)), tui.WithTextStyle(baseStyle), tui.WithWidth(6))
 
 	// Layer indicator with dependency arrow
-	layerSymbol := fmt.Sprintf("%d", m.Layer)
+	layerSymbol := es.vm.DAGLayerLabel(m.Layer)
 	if len(m.DependsOn) > 0 && m.Layer > 0 {
-		layerSymbol = fmt.Sprintf("%d↑", m.Layer) // Arrow indicates it depends on earlier layers
+		layerSymbol += "↑" // Arrow indicates it depends on earlier layers
 	}
-	layerEl := tui.New(tui.WithText(layerSymbol), tui.WithTextStyle(baseStyle), tui.WithWidth(3))
+	layerEl := tui.New(tui.WithText(layerSymbol), tui.WithTextStyle(baseStyle), tui.WithWidth(4))
 
 	nameText := m.Name
 	if es.vm.IsBlocked(m) {

--- a/monitor/internal/tui/components/epic_screen_test.go
+++ b/monitor/internal/tui/components/epic_screen_test.go
@@ -402,9 +402,9 @@ func TestEpicScreenRenderLayerSeparator(t *testing.T) {
 
 	el := es.Render(nil)
 	text := collectAllText(el)
-	// M2 is in Layer 1; a separator row "Layer 1" should appear between M1 and M2
-	if !strings.Contains(text, "Layer 1") {
-		t.Fatalf("expected layer separator 'Layer 1' in output, got: %q", text)
+	// M2 is in Layer 1; a separator row "L1" should appear between M1 and M2
+	if !strings.Contains(text, "── L1 ──") {
+		t.Fatalf("expected layer separator '── L1 ──' in output, got: %q", text)
 	}
 	// Connector symbol │ should appear in the separator
 	if !strings.Contains(text, "│") {
@@ -440,8 +440,8 @@ func TestEpicScreenNoLayerSeparatorSameLayer(t *testing.T) {
 	el := es.Render(nil)
 	text := collectAllText(el)
 	// No milestone is in a higher layer, so no layer separator row should appear.
-	// Separators use the format "── Layer N ──"; the header line uses "Layer 0" but not "── Layer".
-	if strings.Contains(text, "── Layer") {
+	// Separators use the format "── LN ──"; the header line uses "L0" but not "── L".
+	if strings.Contains(text, "── L1") || strings.Contains(text, "── L2") {
 		t.Fatalf("expected no layer separator row when all milestones share layer 0, got: %q", text)
 	}
 }
@@ -465,4 +465,153 @@ func TestEpicScreenRenderNoBlockedWhenDepDone(t *testing.T) {
 	if strings.Contains(text, "BLOCKED") {
 		t.Fatalf("expected no 'BLOCKED' when dep is done, got: %q", text)
 	}
+}
+
+// --- 20. DAG layer label in rendered output ---
+
+func TestEpicScreenRenderDAGLayerLabels(t *testing.T) {
+	store := testStoreWithEpicAndIssues()
+	es := NewEpicScreen(store)
+
+	el := es.Render(nil)
+	text := collectAllText(el)
+	// Layer column should show L0 and L1
+	if !strings.Contains(text, "L0") {
+		t.Fatalf("expected 'L0' layer label in output, got: %q", text)
+	}
+	if !strings.Contains(text, "L1") {
+		t.Fatalf("expected 'L1' layer label in output, got: %q", text)
+	}
+}
+
+// --- 21. DAG layer arrow indicator ---
+
+func TestEpicScreenRenderDAGArrowIndicator(t *testing.T) {
+	store := testStoreWithEpicAndIssues()
+	es := NewEpicScreen(store)
+
+	el := es.Render(nil)
+	text := collectAllText(el)
+	// M2 has deps and is layer 1 -> should show "L1↑"
+	if !strings.Contains(text, "L1↑") {
+		t.Fatalf("expected 'L1↑' dependency arrow in output, got: %q", text)
+	}
+}
+
+// --- 22. DAG box-drawing prefix in rendered output ---
+
+func TestEpicScreenRenderDAGBoxDrawingPrefix(t *testing.T) {
+	store := testStoreWithEpicAndIssues()
+	es := NewEpicScreen(store)
+
+	el := es.Render(nil)
+	text := collectAllText(el)
+	// M1 is root in a DAG -> should have ┌─ prefix
+	if !strings.Contains(text, "┌─") {
+		t.Fatalf("expected '┌─' box-drawing prefix for root milestone, got: %q", text)
+	}
+	// M2 is last in last layer -> should have └─ prefix
+	if !strings.Contains(text, "└─") {
+		t.Fatalf("expected '└─' box-drawing prefix for leaf milestone, got: %q", text)
+	}
+}
+
+// --- 23. DAG summary line shows "DAG arrows" when deps exist ---
+
+func TestEpicScreenRenderDAGSummaryWithDeps(t *testing.T) {
+	store := testStoreWithEpicAndIssues()
+	es := NewEpicScreen(store)
+
+	el := es.Render(nil)
+	text := collectAllText(el)
+	if !strings.Contains(text, "DAG arrows show dependencies") {
+		t.Fatalf("expected DAG arrows info in summary, got: %q", text)
+	}
+}
+
+func TestEpicScreenRenderDAGSummaryNoDeps(t *testing.T) {
+	store := testStoreWithEpic()
+	es := NewEpicScreen(store)
+
+	el := es.Render(nil)
+	text := collectAllText(el)
+	if strings.Contains(text, "DAG arrows show dependencies") {
+		t.Fatalf("should not show DAG arrows info when no deps, got: %q", text)
+	}
+}
+
+// --- 24. Diamond DAG rendering ---
+
+func TestEpicScreenRenderDiamondDAG(t *testing.T) {
+	s := state.NewStore()
+	s.SetPlan(client.Plan{
+		Epic: client.EpicConfig{
+			Name:        "diamond-test",
+			Description: "Diamond dependency pattern",
+			Milestones: []client.Milestone{
+				{ID: 1, Name: "Lint compliance", Status: "done", PhaseStatus: map[string]string{"plan": "done"}},
+				{ID: 2, Name: "Test coverage", Status: "done", DependsOn: []int{1}, PhaseStatus: map[string]string{"plan": "done"}},
+				{ID: 3, Name: "ViewModel arch", Status: "done", DependsOn: []int{1}, PhaseStatus: map[string]string{"plan": "done"}},
+				{ID: 5, Name: "API enhancements", Status: "done", DependsOn: []int{1}, PhaseStatus: map[string]string{"plan": "done"}},
+				{ID: 4, Name: "TUI features", Status: "in_progress", DependsOn: []int{2, 3, 5}, PhaseStatus: map[string]string{"plan": "in_progress"}},
+			},
+		},
+	})
+	es := NewEpicScreen(s)
+
+	el := es.Render(nil)
+	text := collectAllText(el)
+
+	// All milestone names should appear
+	for _, name := range []string{"Lint compliance", "Test coverage", "ViewModel arch", "API enhancements", "TUI features"} {
+		if !strings.Contains(text, name) {
+			t.Errorf("expected milestone %q in output", name)
+		}
+	}
+
+	// Layer labels should appear
+	if !strings.Contains(text, "L0") {
+		t.Error("expected L0 layer label")
+	}
+	if !strings.Contains(text, "L1") {
+		t.Error("expected L1 layer label")
+	}
+	if !strings.Contains(text, "L2") {
+		t.Error("expected L2 layer label")
+	}
+
+	// Box-drawing connectors
+	if !strings.Contains(text, "┌─") {
+		t.Error("expected ┌─ for root milestone")
+	}
+	if !strings.Contains(text, "├─") {
+		t.Error("expected ├─ for middle milestones")
+	}
+	if !strings.Contains(text, "└─") {
+		t.Error("expected └─ for leaf milestone")
+	}
+
+	// Layer separators
+	if !strings.Contains(text, "── L1 ──") {
+		t.Error("expected layer separator for L1")
+	}
+	if !strings.Contains(text, "── L2 ──") {
+		t.Error("expected layer separator for L2")
+	}
+}
+
+// --- 25. No DAG connectors for flat milestone list ---
+
+func TestEpicScreenRenderFlatListNoConnectors(t *testing.T) {
+	store := testStoreWithEpic()
+	es := NewEpicScreen(store)
+
+	el := es.Render(nil)
+	text := collectAllText(el)
+	// No box-drawing connectors should appear for flat list
+	if strings.Contains(text, "┌─") {
+		t.Fatalf("should not have ┌─ in flat list, got: %q", text)
+	}
+	// └─ should also not appear (only DAG prefix, not issue tree)
+	// Note: ├─ is used by issue tree connectors, so skip checking that
 }

--- a/monitor/internal/tui/views/epic_viewmodel.go
+++ b/monitor/internal/tui/views/epic_viewmodel.go
@@ -301,15 +301,105 @@ func (vm *EpicViewModel) DAGConnectors() []DAGConnector {
 }
 
 // DAGPrefix returns a visual prefix string for a milestone indicating its DAG relationships.
-// Uses box-drawing characters to show dependency structure.
+// Uses box-drawing characters to show dependency structure:
+//   - "┌─" for the first milestone in a layer group
+//   - "├─" for middle milestones in a layer group
+//   - "└─" for the last milestone in the last layer, or the last in a group with more layers below
+//   - "│ " for continuation when there are more items below (not applicable here — used in connectors)
 func (vm *EpicViewModel) DAGPrefix(m MilestoneStatus) string {
 	if vm == nil {
 		return ""
 	}
-	if len(m.DependsOn) == 0 {
-		return "  " // root node, no connector
+	maxLayer := vm.MaxLayer()
+	if maxLayer <= 0 {
+		// No DAG structure (all layer 0 or single layer) — no connectors needed
+		return "  "
 	}
-	return "└─" // dependent node
+
+	// Count milestones in this layer and find position
+	posInLayer := 0
+	countInLayer := 0
+	for _, ms := range vm.milestones {
+		if ms.Layer == m.Layer {
+			if ms.ID == m.ID {
+				posInLayer = countInLayer
+			}
+			countInLayer++
+		}
+	}
+
+	isLastLayer := m.Layer == maxLayer
+	isFirstInLayer := posInLayer == 0
+	isLastInLayer := posInLayer == countInLayer-1
+
+	if isLastLayer && isLastInLayer {
+		return "└─"
+	}
+	if isFirstInLayer && m.Layer == 0 {
+		return "┌─"
+	}
+	if isLastInLayer && !isLastLayer {
+		return "├─"
+	}
+	return "├─"
+}
+
+// DAGLayerLabel returns the layer label string for a given layer number (e.g., "L0", "L1").
+func (vm *EpicViewModel) DAGLayerLabel(layer int) string {
+	if vm == nil {
+		return ""
+	}
+	return fmt.Sprintf("L%d", layer)
+}
+
+// DAGLayout returns milestones sorted by layer for rendering, along with
+// metadata about where layer boundaries occur. This is the primary method
+// for rendering the DAG visualization.
+// Returns nil if there are no milestones.
+func (vm *EpicViewModel) DAGLayout() []DAGLayoutEntry {
+	if vm == nil || len(vm.milestones) == 0 {
+		return nil
+	}
+
+	maxLayer := vm.MaxLayer()
+	var layout []DAGLayoutEntry
+
+	for layer := 0; layer <= maxLayer; layer++ {
+		var layerMilestones []MilestoneStatus
+		for _, m := range vm.milestones {
+			if m.Layer == layer {
+				layerMilestones = append(layerMilestones, m)
+			}
+		}
+		for i, m := range layerMilestones {
+			layout = append(layout, DAGLayoutEntry{
+				Milestone:    m,
+				Layer:        layer,
+				IsFirstInLayer: i == 0,
+				IsLastInLayer:  i == len(layerMilestones)-1,
+				IsLastLayer:    layer == maxLayer,
+			})
+		}
+	}
+
+	return layout
+}
+
+// DAGLayoutEntry describes a single milestone's position in the DAG layout.
+type DAGLayoutEntry struct {
+	Milestone      MilestoneStatus
+	Layer          int
+	IsFirstInLayer bool
+	IsLastInLayer  bool
+	IsLastLayer    bool
+}
+
+// HasDAG returns true if the milestone graph has any dependency structure (more than one layer).
+func (vm *EpicViewModel) HasDAG() bool {
+	if vm == nil {
+		return false
+	}
+	return vm.MaxLayer() > 0
 }
 
 // IsBlocked returns true if the milestone has unmet dependencies (any dep not "done").

--- a/monitor/internal/tui/views/epic_viewmodel_test.go
+++ b/monitor/internal/tui/views/epic_viewmodel_test.go
@@ -898,16 +898,30 @@ func TestDAGPrefix(t *testing.T) {
 	vm := views.NewEpicViewModel(store)
 	ms := vm.Milestones()
 
-	// M1 has no deps -> "  "
+	// M1 has no deps but DAG exists -> "┌─" (first in layer 0 with DAG structure)
 	prefix0 := vm.DAGPrefix(ms[0])
-	if prefix0 != "  " {
-		t.Errorf("DAGPrefix for root = %q, want \"  \"", prefix0)
+	if prefix0 != "┌─" {
+		t.Errorf("DAGPrefix for root in DAG = %q, want \"┌─\"", prefix0)
 	}
 
-	// M2 depends on M1 -> "└─"
+	// M2 depends on M1, last in last layer -> "└─"
 	prefix1 := vm.DAGPrefix(ms[1])
 	if prefix1 != "└─" {
 		t.Errorf("DAGPrefix for dependent = %q, want \"└─\"", prefix1)
+	}
+}
+
+func TestDAGPrefixNoDeps(t *testing.T) {
+	// When no DAG structure at all (all milestones in layer 0), prefix is "  "
+	store := seedEpicStore()
+	vm := views.NewEpicViewModel(store)
+	ms := vm.Milestones()
+
+	for _, m := range ms {
+		prefix := vm.DAGPrefix(m)
+		if prefix != "  " {
+			t.Errorf("DAGPrefix for milestone %q with no DAG = %q, want \"  \"", m.Name, prefix)
+		}
 	}
 }
 
@@ -982,5 +996,432 @@ func TestIsBlockedDoneMilestoneNotBlocked(t *testing.T) {
 	// M2 is "done" — should never show as blocked even though dep M1 is not done
 	if vm.IsBlocked(ms[1]) {
 		t.Error("done milestone should not be blocked even if dep is not done")
+	}
+}
+
+// ── DAG Layer Computation ─────────────────────────────────────────────────
+
+func TestDAGLayerNoDependencies(t *testing.T) {
+	store := state.NewStore()
+	store.SetPlan(client.Plan{
+		Epic: client.EpicConfig{
+			Name: "test",
+			Milestones: []client.Milestone{
+				{ID: 1, Name: "A", Status: "pending"},
+				{ID: 2, Name: "B", Status: "pending"},
+				{ID: 3, Name: "C", Status: "pending"},
+			},
+		},
+	})
+	vm := views.NewEpicViewModel(store)
+	ms := vm.Milestones()
+
+	for _, m := range ms {
+		if m.Layer != 0 {
+			t.Errorf("milestone %q Layer = %d, want 0 (no deps)", m.Name, m.Layer)
+		}
+	}
+	if vm.MaxLayer() != 0 {
+		t.Errorf("MaxLayer = %d, want 0", vm.MaxLayer())
+	}
+}
+
+func TestDAGLayerLinearChain(t *testing.T) {
+	// M1 -> M2 -> M3 -> M4: linear dependency chain
+	store := state.NewStore()
+	store.SetPlan(client.Plan{
+		Epic: client.EpicConfig{
+			Name: "test",
+			Milestones: []client.Milestone{
+				{ID: 1, Name: "M1", Status: "done"},
+				{ID: 2, Name: "M2", Status: "done", DependsOn: []int{1}},
+				{ID: 3, Name: "M3", Status: "in_progress", DependsOn: []int{2}},
+				{ID: 4, Name: "M4", Status: "pending", DependsOn: []int{3}},
+			},
+		},
+	})
+	vm := views.NewEpicViewModel(store)
+	ms := vm.Milestones()
+
+	expectedLayers := []int{0, 1, 2, 3}
+	for i, m := range ms {
+		if m.Layer != expectedLayers[i] {
+			t.Errorf("milestone %q Layer = %d, want %d", m.Name, m.Layer, expectedLayers[i])
+		}
+	}
+	if vm.MaxLayer() != 3 {
+		t.Errorf("MaxLayer = %d, want 3", vm.MaxLayer())
+	}
+}
+
+func TestDAGLayerDiamondPattern(t *testing.T) {
+	// Diamond: M1 -> M2, M1 -> M3, M2+M3 -> M4
+	store := state.NewStore()
+	store.SetPlan(client.Plan{
+		Epic: client.EpicConfig{
+			Name: "test",
+			Milestones: []client.Milestone{
+				{ID: 1, Name: "M1", Status: "done"},
+				{ID: 2, Name: "M2", Status: "done", DependsOn: []int{1}},
+				{ID: 3, Name: "M3", Status: "done", DependsOn: []int{1}},
+				{ID: 4, Name: "M4", Status: "pending", DependsOn: []int{2, 3}},
+			},
+		},
+	})
+	vm := views.NewEpicViewModel(store)
+	ms := vm.Milestones()
+
+	// M1=L0, M2=L1, M3=L1, M4=L2
+	if ms[0].Layer != 0 {
+		t.Errorf("M1 Layer = %d, want 0", ms[0].Layer)
+	}
+	if ms[1].Layer != 1 {
+		t.Errorf("M2 Layer = %d, want 1", ms[1].Layer)
+	}
+	if ms[2].Layer != 1 {
+		t.Errorf("M3 Layer = %d, want 1", ms[2].Layer)
+	}
+	if ms[3].Layer != 2 {
+		t.Errorf("M4 Layer = %d, want 2", ms[3].Layer)
+	}
+	if vm.MaxLayer() != 2 {
+		t.Errorf("MaxLayer = %d, want 2", vm.MaxLayer())
+	}
+}
+
+func TestDAGLayerCircularDepsHandled(t *testing.T) {
+	// Circular: M1 -> M2 -> M1 (should not infinite loop; unresolvable nodes stay at layer 0)
+	store := state.NewStore()
+	store.SetPlan(client.Plan{
+		Epic: client.EpicConfig{
+			Name: "test",
+			Milestones: []client.Milestone{
+				{ID: 1, Name: "M1", Status: "pending", DependsOn: []int{2}},
+				{ID: 2, Name: "M2", Status: "pending", DependsOn: []int{1}},
+			},
+		},
+	})
+	vm := views.NewEpicViewModel(store)
+	ms := vm.Milestones()
+
+	// Both milestones are in a cycle; calculateDAGLayers breaks the cycle by
+	// leaving them unassigned (layer 0 is the default for the map).
+	// The key test is that this does not hang or panic.
+	if len(ms) != 2 {
+		t.Fatalf("expected 2 milestones, got %d", len(ms))
+	}
+}
+
+func TestDAGLayerMissingDepID(t *testing.T) {
+	// M2 depends on ID 99 which doesn't exist — should not panic
+	store := state.NewStore()
+	store.SetPlan(client.Plan{
+		Epic: client.EpicConfig{
+			Name: "test",
+			Milestones: []client.Milestone{
+				{ID: 1, Name: "M1", Status: "done"},
+				{ID: 2, Name: "M2", Status: "pending", DependsOn: []int{99}},
+			},
+		},
+	})
+	vm := views.NewEpicViewModel(store)
+	ms := vm.Milestones()
+
+	// M1 has no deps -> L0
+	if ms[0].Layer != 0 {
+		t.Errorf("M1 Layer = %d, want 0", ms[0].Layer)
+	}
+	// M2 depends on nonexistent 99: unresolvable, stays at default (0)
+	// The important thing is no panic.
+	if len(ms) != 2 {
+		t.Fatalf("expected 2 milestones, got %d", len(ms))
+	}
+}
+
+func TestDAGLayerParallelRoots(t *testing.T) {
+	// Two parallel roots, both converge to one milestone
+	// M1 (L0), M2 (L0) -> M3 (L1)
+	store := state.NewStore()
+	store.SetPlan(client.Plan{
+		Epic: client.EpicConfig{
+			Name: "test",
+			Milestones: []client.Milestone{
+				{ID: 1, Name: "M1", Status: "done"},
+				{ID: 2, Name: "M2", Status: "done"},
+				{ID: 3, Name: "M3", Status: "pending", DependsOn: []int{1, 2}},
+			},
+		},
+	})
+	vm := views.NewEpicViewModel(store)
+	ms := vm.Milestones()
+
+	if ms[0].Layer != 0 {
+		t.Errorf("M1 Layer = %d, want 0", ms[0].Layer)
+	}
+	if ms[1].Layer != 0 {
+		t.Errorf("M2 Layer = %d, want 0", ms[1].Layer)
+	}
+	if ms[2].Layer != 1 {
+		t.Errorf("M3 Layer = %d, want 1", ms[2].Layer)
+	}
+}
+
+// ── DAGLayout ────────────────────────────────────────────────────────────
+
+func TestDAGLayoutOrdersByLayer(t *testing.T) {
+	store := state.NewStore()
+	store.SetPlan(client.Plan{
+		Epic: client.EpicConfig{
+			Name: "test",
+			Milestones: []client.Milestone{
+				{ID: 1, Name: "M1", Status: "done"},
+				{ID: 2, Name: "M2", Status: "done", DependsOn: []int{1}},
+				{ID: 3, Name: "M3", Status: "done", DependsOn: []int{1}},
+				{ID: 4, Name: "M4", Status: "pending", DependsOn: []int{2, 3}},
+			},
+		},
+	})
+	vm := views.NewEpicViewModel(store)
+	layout := vm.DAGLayout()
+
+	if len(layout) != 4 {
+		t.Fatalf("expected 4 layout entries, got %d", len(layout))
+	}
+
+	// Verify layer ordering: L0, L1, L1, L2
+	expectedLayers := []int{0, 1, 1, 2}
+	for i, entry := range layout {
+		if entry.Layer != expectedLayers[i] {
+			t.Errorf("layout[%d].Layer = %d, want %d", i, entry.Layer, expectedLayers[i])
+		}
+	}
+
+	// First in layer flags
+	if !layout[0].IsFirstInLayer {
+		t.Error("layout[0] should be first in layer 0")
+	}
+	if !layout[1].IsFirstInLayer {
+		t.Error("layout[1] should be first in layer 1")
+	}
+	if layout[2].IsFirstInLayer {
+		t.Error("layout[2] should NOT be first in layer 1")
+	}
+	if !layout[3].IsFirstInLayer {
+		t.Error("layout[3] should be first in layer 2")
+	}
+
+	// Last in layer flags
+	if !layout[0].IsLastInLayer {
+		t.Error("layout[0] should be last in layer 0 (only item)")
+	}
+	if layout[1].IsLastInLayer {
+		t.Error("layout[1] should NOT be last in layer 1")
+	}
+	if !layout[2].IsLastInLayer {
+		t.Error("layout[2] should be last in layer 1")
+	}
+	if !layout[3].IsLastInLayer {
+		t.Error("layout[3] should be last in layer 2")
+	}
+
+	// IsLastLayer flags
+	if layout[0].IsLastLayer {
+		t.Error("layout[0] should NOT be in last layer")
+	}
+	if layout[1].IsLastLayer {
+		t.Error("layout[1] should NOT be in last layer")
+	}
+	if layout[2].IsLastLayer {
+		t.Error("layout[2] should NOT be in last layer")
+	}
+	if !layout[3].IsLastLayer {
+		t.Error("layout[3] should be in last layer")
+	}
+}
+
+func TestDAGLayoutNilReceiver(t *testing.T) {
+	var vm *views.EpicViewModel
+	if vm.DAGLayout() != nil {
+		t.Error("nil receiver DAGLayout should return nil")
+	}
+}
+
+func TestDAGLayoutEmpty(t *testing.T) {
+	store := state.NewStore()
+	vm := views.NewEpicViewModel(store)
+	if vm.DAGLayout() != nil {
+		t.Error("empty plan DAGLayout should return nil")
+	}
+}
+
+func TestDAGLayoutFlatList(t *testing.T) {
+	// All milestones in layer 0
+	store := seedEpicStore()
+	vm := views.NewEpicViewModel(store)
+	layout := vm.DAGLayout()
+
+	if len(layout) != 4 {
+		t.Fatalf("expected 4 layout entries, got %d", len(layout))
+	}
+	for i, entry := range layout {
+		if entry.Layer != 0 {
+			t.Errorf("layout[%d].Layer = %d, want 0", i, entry.Layer)
+		}
+	}
+}
+
+// ── HasDAG ─────────────────────────────────────────────────────────────
+
+func TestHasDAGTrue(t *testing.T) {
+	store := seedEpicStoreWithIssues()
+	vm := views.NewEpicViewModel(store)
+	if !vm.HasDAG() {
+		t.Error("HasDAG should be true when milestones have dependencies")
+	}
+}
+
+func TestHasDAGFalse(t *testing.T) {
+	store := seedEpicStore()
+	vm := views.NewEpicViewModel(store)
+	if vm.HasDAG() {
+		t.Error("HasDAG should be false when no milestones have dependencies")
+	}
+}
+
+func TestHasDAGNilReceiver(t *testing.T) {
+	var vm *views.EpicViewModel
+	if vm.HasDAG() {
+		t.Error("nil receiver HasDAG should return false")
+	}
+}
+
+// ── DAGLayerLabel ──────────────────────────────────────────────────────
+
+func TestDAGLayerLabel(t *testing.T) {
+	store := seedEpicStore()
+	vm := views.NewEpicViewModel(store)
+
+	tests := []struct {
+		layer int
+		want  string
+	}{
+		{0, "L0"},
+		{1, "L1"},
+		{2, "L2"},
+		{10, "L10"},
+	}
+	for _, tt := range tests {
+		got := vm.DAGLayerLabel(tt.layer)
+		if got != tt.want {
+			t.Errorf("DAGLayerLabel(%d) = %q, want %q", tt.layer, got, tt.want)
+		}
+	}
+}
+
+func TestDAGLayerLabelNilReceiver(t *testing.T) {
+	var vm *views.EpicViewModel
+	if vm.DAGLayerLabel(0) != "" {
+		t.Error("nil receiver DAGLayerLabel should return empty string")
+	}
+}
+
+// ── DAGPrefix with various topologies ──────────────────────────────────
+
+func TestDAGPrefixLinearChain(t *testing.T) {
+	store := state.NewStore()
+	store.SetPlan(client.Plan{
+		Epic: client.EpicConfig{
+			Name: "test",
+			Milestones: []client.Milestone{
+				{ID: 1, Name: "M1", Status: "done"},
+				{ID: 2, Name: "M2", Status: "done", DependsOn: []int{1}},
+				{ID: 3, Name: "M3", Status: "pending", DependsOn: []int{2}},
+			},
+		},
+	})
+	vm := views.NewEpicViewModel(store)
+	ms := vm.Milestones()
+
+	// M1: layer 0, first and only in layer, not last layer -> ┌─
+	if p := vm.DAGPrefix(ms[0]); p != "┌─" {
+		t.Errorf("M1 prefix = %q, want \"┌─\"", p)
+	}
+	// M2: layer 1, middle layer -> ├─
+	if p := vm.DAGPrefix(ms[1]); p != "├─" {
+		t.Errorf("M2 prefix = %q, want \"├─\"", p)
+	}
+	// M3: layer 2, last layer last item -> └─
+	if p := vm.DAGPrefix(ms[2]); p != "└─" {
+		t.Errorf("M3 prefix = %q, want \"└─\"", p)
+	}
+}
+
+func TestDAGPrefixDiamondPattern(t *testing.T) {
+	store := state.NewStore()
+	store.SetPlan(client.Plan{
+		Epic: client.EpicConfig{
+			Name: "test",
+			Milestones: []client.Milestone{
+				{ID: 1, Name: "M1", Status: "done"},
+				{ID: 2, Name: "M2", Status: "done", DependsOn: []int{1}},
+				{ID: 3, Name: "M3", Status: "done", DependsOn: []int{1}},
+				{ID: 4, Name: "M4", Status: "pending", DependsOn: []int{2, 3}},
+			},
+		},
+	})
+	vm := views.NewEpicViewModel(store)
+	ms := vm.Milestones()
+
+	// M1: layer 0, root -> ┌─
+	if p := vm.DAGPrefix(ms[0]); p != "┌─" {
+		t.Errorf("M1 prefix = %q, want \"┌─\"", p)
+	}
+	// M2: layer 1, first of two in layer -> ├─
+	if p := vm.DAGPrefix(ms[1]); p != "├─" {
+		t.Errorf("M2 prefix = %q, want \"├─\"", p)
+	}
+	// M3: layer 1, last in non-last layer -> ├─
+	if p := vm.DAGPrefix(ms[2]); p != "├─" {
+		t.Errorf("M3 prefix = %q, want \"├─\"", p)
+	}
+	// M4: layer 2, last in last layer -> └─
+	if p := vm.DAGPrefix(ms[3]); p != "└─" {
+		t.Errorf("M4 prefix = %q, want \"└─\"", p)
+	}
+}
+
+// ── MilestonesByLayer ──────────────────────────────────────────────────
+
+func TestMilestonesByLayer(t *testing.T) {
+	store := state.NewStore()
+	store.SetPlan(client.Plan{
+		Epic: client.EpicConfig{
+			Name: "test",
+			Milestones: []client.Milestone{
+				{ID: 1, Name: "M1", Status: "done"},
+				{ID: 2, Name: "M2", Status: "done", DependsOn: []int{1}},
+				{ID: 3, Name: "M3", Status: "done", DependsOn: []int{1}},
+				{ID: 4, Name: "M4", Status: "pending", DependsOn: []int{2, 3}},
+			},
+		},
+	})
+	vm := views.NewEpicViewModel(store)
+	byLayer := vm.MilestonesByLayer()
+
+	if len(byLayer[0]) != 1 {
+		t.Errorf("layer 0: expected 1 milestone, got %d", len(byLayer[0]))
+	}
+	if len(byLayer[1]) != 2 {
+		t.Errorf("layer 1: expected 2 milestones, got %d", len(byLayer[1]))
+	}
+	if len(byLayer[2]) != 1 {
+		t.Errorf("layer 2: expected 1 milestone, got %d", len(byLayer[2]))
+	}
+}
+
+func TestMilestonesByLayerNilReceiver(t *testing.T) {
+	var vm *views.EpicViewModel
+	if vm.MilestonesByLayer() != nil {
+		t.Error("nil receiver MilestonesByLayer should return nil")
 	}
 }


### PR DESCRIPTION
## Summary

- Add topology-aware DAG visualization to TUI epic screen
- Box-drawing connectors: `┌─` (root), `├─` (middle), `└─` (leaf)
- Layer labels: `L0`, `L1`, `L2` grouping milestones by dependency depth
- Layer separator rows with `── L1 ──` format
- Falls back to flat list when no `depends_on` declarations exist
- 22 new tests covering: layer computation, diamond/linear/parallel topologies, circular dep safety, rendering output

## Milestone

M4: TUI features — part of ratchet monitor quality improvements epic

## Test plan

- [x] `go test ./internal/tui/... -v` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Linear chain, diamond, parallel roots, no-deps topologies tested
- [x] Circular dep detection (safety)