### PR TITLE
Caveman compress run skill helper files

### DIFF
--- a/skills/run/issue-pipeline.md
+++ b/skills/run/issue-pipeline.md
@@ -1,29 +1,23 @@
 # Issue Pipeline Specification
 
-> This file is the extracted Step 5 from `skills/run/SKILL.md`.
-> It is loaded on demand when the orchestrator executes an issue pipeline.
-> For the orchestrator flow (Steps 1-4, 6-10), see `skills/run/SKILL.md`.
+> Extracted Step 5 from `skills/run/SKILL.md`. Loaded on demand when orchestrator executes an issue pipeline. For orchestrator flow (Steps 1-4, 6-10), see `skills/run/SKILL.md`.
 
 ---
 
 ### Step 5: Issue Pipeline (executed per-issue in isolated worktrees)
 
-Phase-gated loop for a single issue, spawned by Step 4b as a parallel Agent invocation with its own git worktree.
+Phase-gated loop for a single issue, spawned by Step 4b as parallel Agent invocation with own git worktree.
 
 **Execution context:**
-- **Worktree mode** depends on the issue's dependency layer:
-  - **`isolation: worktree`** (Layer 0) — fresh worktree branching from `origin/main`
-  - **Pre-created worktree** (Layer 1+) — orchestrator creates the worktree from the dependency's `branch` field in plan.yaml (see Step 4b "Branch base resolution"). Inherits the dependency's committed changes.
-- **Strategy** depends on the component's `strategy` field:
-  - `debate` (default): spawns debate-runner agents at Step 5e
-  - `solo`: spawns generative agent directly at Step 5e-solo, skipping the debate-runner
-- Returns a structured completion summary (Step 5h) — does NOT write plan.yaml (parent orchestrator handles that in Step 4c)
+- **Worktree mode** by dependency layer: **`isolation: worktree`** (Layer 0) — fresh worktree from `origin/main`; **Pre-created worktree** (Layer 1+) — orchestrator creates from dependency's `branch` field in plan.yaml (Step 4b "Branch base resolution"), inheriting committed changes.
+- **Strategy** from component's `strategy` field: `debate` (default) spawns debate-runner agents at Step 5e; `solo` spawns generative agent directly at Step 5e-solo.
+- Returns structured completion summary (Step 5h) — does NOT write plan.yaml (parent orchestrator handles in Step 4c).
 
-Phases progress sequentially (plan → test → build → review → harden, depending on pipeline preset), then control returns to Step 4c.
+Phases progress sequentially (plan → test → build → review → harden, per pipeline preset), then control returns to Step 4c.
 
 #### Guard Execution Pattern
 
-All guard invocations (Steps 5c, 5e-solo, 5f) use this pattern:
+All guard invocations (Steps 5c, 5e-solo, 5f):
 
 ```bash
 test -f .claude/ratchet-scripts/run-guards.sh \
@@ -99,7 +93,7 @@ Context:
 
 #### Guilt Verification Pattern
 
-When a blocking guard fails, the failure is **guilty until proven innocent** — caused by the current issue's changes unless proven otherwise. Verify on clean base before dismissing:
+When blocking guard fails, failure is **guilty until proven innocent** — caused by current issue's changes unless proven otherwise. Verify on clean base before dismissing:
 
 ```bash
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -114,40 +108,28 @@ git stash pop 2>/dev/null
 
 #### 5-pre. Worktree Mode Detection and Dependency Validation
 
-**1. Detect worktree mode** from prompt context fields set by Step 4b:
-- `Worktree mode: isolation` (or absent) → **isolation mode** (Layer 0)
-- `Worktree mode: pre-created` with `Dependency branch` and `Dependency files` → **pre-created mode** (Layer 1+)
+**1. Detect worktree mode** from prompt context fields set by Step 4b: `Worktree mode: isolation` (or absent) → **isolation mode** (Layer 0); `Worktree mode: pre-created` with `Dependency branch`/`Dependency files` → **pre-created mode** (Layer 1+). Log: `Worktree mode: [isolation|pre-created]` (if pre-created, include base branch and dep refs).
 
-Log: `Worktree mode: [isolation|pre-created]` (if pre-created, include base branch and dep refs).
-
-**2. Validate dependency changes (pre-created mode only):**
-
-For each file in the `dependency_files` array, verify it exists and is modified relative to `origin/main`. Validation outcomes:
+**2. Validate dependency changes (pre-created mode only):** For each file in `dependency_files` array, verify it exists and is modified relative to `origin/main`. Outcomes:
 - **All files present and modified** → proceed. Log: `"Dependency validation passed: [N] files verified"`
-- **Files missing or unmodified** → critical error:
-  - **Supervised**: `AskUserQuestion` with options: `"Re-create worktree"`, `"Override and proceed"`, `"Cancel this issue"`
-  - **Unsupervised**: halt with status `blocked`
+- **Files missing or unmodified** → critical error. **Supervised**: `AskUserQuestion` with options: `"Re-create worktree"`, `"Override and proceed"`, `"Cancel this issue"`. **Unsupervised**: halt with status `blocked`.
 
-**3. Set git baseline for guilt checks:**
-- **Isolation mode**: `GUILT_BASE_REF="origin/main"`
-- **Pre-created mode**: `GUILT_BASE_REF=$(git rev-parse HEAD)` (captured before any issue work)
-
-This replaces the implicit `origin/main` assumption in guard failure verification throughout the pipeline.
+**3. Set git baseline for guilt checks:** **Isolation mode**: `GUILT_BASE_REF="origin/main"`. **Pre-created mode**: `GUILT_BASE_REF=$(git rev-parse HEAD)` (captured before any issue work). Replaces the implicit `origin/main` assumption in guard failure verification throughout the pipeline.
 
 #### 5a. Determine Current Phase and Match Pairs
 
 **[TodoWrite — Phase Starts]**: Set this phase item to `"in_progress"` with pair names.
 
-1. Read the issue's `phase_status` — find the first `pending` or `in_progress` phase
-2. Determine applicable phases from the component's `pipeline` preset:
+1. Read issue's `phase_status` — find first `pending` or `in_progress` phase
+2. Determine applicable phases from component's `pipeline` preset:
    - `full`: plan → test → build → review → harden
    - `standard`: plan → build → review → harden
    - `review`: review only
    - `hotfix`: build → review
    - `secure`: review → harden
-3. Resolve the component's `strategy` field (`debate` or `solo`, default: `debate`)
-4. Match pairs from the issue's `pairs` list for the current phase; skip disabled pairs
-5. If a pair has `scope: "auto"`, resolve to the parent component's scope glob
+3. Resolve component's `strategy` field (`debate` or `solo`, default: `debate`)
+4. Match pairs from issue's `pairs` list for current phase; skip disabled pairs
+5. If pair has `scope: "auto"`, resolve to parent component's scope glob
 
 #### 5b. File-Hash Cache Check
 
@@ -155,27 +137,20 @@ This replaces the implicit `origin/main` assumption in guard failure verificatio
 bash .claude/ratchet-scripts/cache-check.sh <pair-name> "<scope-glob>"
 ```
 
-- Exit 0 → skip pair (no changes since last consensus)
-- Exit 1 → proceed to execution
-
-Use `--no-cache` to force re-execution.
+Exit 0 → skip pair (no changes since last consensus). Exit 1 → proceed to execution. `--no-cache` forces re-execution.
 
 #### Shared Resources
 
 Guards can declare `requires: [resource-name]` referencing shared resources in workflow.yaml — infrastructure dependencies needing provisioning and optionally singleton access.
 
 **Lifecycle:**
-1. **Provision** — run the resource's `start` command (must be idempotent). Track in `.ratchet/locks/resources.json`.
-2. **Lock + Run** — if `singleton: true`, wrap the guard command with `flock` (kernel-level file locking in `.ratchet/locks/`). Lock auto-releases on exit — no stale locks, no cleanup.
+1. **Provision** — run resource's `start` command (idempotent). Track in `.ratchet/locks/resources.json`.
+2. **Lock + Run** — if `singleton: true`, wrap guard command with `flock` (kernel file locking in `.ratchet/locks/`). Auto-releases on exit — no stale locks.
 3. **Teardown** (Step 9) — run `stop` commands, remove `.ratchet/locks/`.
 
 #### 5c. Pre-Execution Guards
 
-Run guards where `timing: "pre-execution"` (or deprecated `"pre-debate"`) for the current phase. Guards without `timing` default to `post-execution`.
-
-If guard has `requires`: provision resources. For singleton resources, wrap with `flock`.
-
-Invoke using the **Guard Execution Pattern** above.
+Run guards where `timing: "pre-execution"` (or deprecated `"pre-debate"`) for current phase. Guards without `timing` default to `post-execution`. If guard has `requires`: provision resources; for singleton, wrap with `flock`. Invoke using **Guard Execution Pattern** above.
 
 - **Blocking guard fails** → verify using **Guilt Verification Pattern**. Then `AskUserQuestion`: `"Fix and re-run"`, `"Override and proceed"`, `"Cancel — skip this phase"`. If fix or cancel: skip execution entirely.
 - **Advisory guard fails** → log and pass output as context to execution (guilty until proven innocent). Continue.
@@ -188,17 +163,11 @@ For each matched pair:
 3. **Gather phase context**: plan output (if phase > plan), test locations (if phase > test), unresolved CONDITIONAL_ACCEPT conditions
 4. **Resolve models**: pair-level overrides over global. Debate needs `generative`, `adversarial`, `tiebreaker`. Solo needs only `generative`.
 5. **Resolve `progress_ref`** (debate only): use `ref` if numeric, else `null`. Pass to debate-runner for `meta.json` at creation (before round files trigger publish hook).
-6. **Resolve caveman config**: Read from the values already computed in Step 1b:
-   - If `caveman_enabled` is `true`, pass the per-role intensities (`caveman_generative`, `caveman_adversarial`, `caveman_tiebreaker`, `caveman_debate_runner`)
-   - If `caveman_enabled` is `false` (or absent), pass all roles as `off`
-   - The `orchestrator` intensity is NOT passed to the debate-runner — it governs the run skill's own behavior
+6. **Resolve caveman config** from values computed in Step 1b: if `caveman_enabled` is `true`, pass per-role intensities (`caveman_generative`, `caveman_adversarial`, `caveman_tiebreaker`, `caveman_debate_runner`); if `false` or absent, pass all roles as `off`. The `orchestrator` intensity is NOT passed to debate-runner — governs the run skill's own behavior.
 
 #### 5e. Execute Phase (Strategy Branch)
 
-- **`strategy: "debate"`** → Step 5e-debate
-- **`strategy: "solo"`** → Step 5e-solo
-
-Both paths converge at Step 5f.
+**`strategy: "debate"`** → Step 5e-debate. **`strategy: "solo"`** → Step 5e-solo. Both paths converge at Step 5f.
 
 ---
 
@@ -208,11 +177,11 @@ Single generative agent executes the phase; post-execution guards serve as quali
 
 **1. Create execution log** in `.ratchet/executions/<pair-name>-<timestamp>.yaml` with fields: `id`, `mode: solo`, `component`, `issue`, `started`, `resolved: null`, `guard_results: []`, `promoted: false`, `debate_id: null`, `files_modified: []`.
 
-**2. Spawn generative agent** with resolved `generative` model. Tools: Read, Grep, Glob, Bash, Write, Edit. Agent receives phase, pair definition, worktree path, milestone, issue, files in scope, and prior phase outputs.
+**2. Spawn generative agent** with resolved `generative` model. Tools: Read, Grep, Glob, Bash, Write, Edit. Receives phase, pair definition, worktree path, milestone, issue, files in scope, prior phase outputs.
 
-**3. Process result**: capture `files_modified` from worktree (`git diff --name-only` + staged + untracked). Update execution log with files and `resolved` timestamp.
+**3. Process result**: capture `files_modified` (`git diff --name-only` + staged + untracked). Update execution log with files and `resolved` timestamp.
 
-**4. Run post-execution guards** using the **Guard Execution Pattern**. Record each result in execution log.
+**4. Run post-execution guards** using **Guard Execution Pattern**. Record each result in log.
 
 **5. Handle guard results:**
 
@@ -237,68 +206,45 @@ Spawn a **debate-runner** agent per matched pair (parallel when multiple). Model
 - Adversarial agent: Read, Grep, Glob, Bash — no Write/Edit (read-only)
 - Tiebreaker agent: Read, Grep, Glob, Bash — no Write/Edit (read-only)
 
-Each debate-runner receives: pair definitions, worktree path, phase, milestone, issue ref, files in scope, max rounds, escalation policy/precedents, prior phase outputs, `progress_ref`, and resolved models (generative/adversarial/tiebreaker).
+Each debate-runner receives: pair definitions, worktree path, phase, milestone, issue ref, files in scope, max rounds, escalation policy/precedents, prior phase outputs, `progress_ref`, resolved models (generative/adversarial/tiebreaker). The `progress_ref` MUST be written into `meta.json` at debate creation before any round files trigger the publish hook.
 
-The `progress_ref` MUST be written into `meta.json` at debate creation before any round files trigger the publish hook.
-
-**If debate-runner cannot be spawned:**
-- **Supervised**: `AskUserQuestion` with options: `"Wait and retry"`, `"Skip this phase"`, `"Escalate for manual resolution"`
-- **Unsupervised**: halt with status `blocked` ("debate-runner unavailable — quality gate cannot be enforced")
-- Retry: up to 3 times with exponential backoff (5s, 10s, 20s)
+**If debate-runner cannot be spawned:** **Supervised** → `AskUserQuestion`: `"Wait and retry"`, `"Skip this phase"`, `"Escalate for manual resolution"`. **Unsupervised** → halt with status `blocked` ("debate-runner unavailable — quality gate cannot be enforced"). Retry up to 3 times with exponential backoff (5s, 10s, 20s).
 
 **No fallback validation** (debate mode): the debate-runner is the ONLY acceptable quality path. Guards alone are insufficient substitutes. For solo mode, guards ARE the quality gate by design.
 
 #### Handle Debate Results (strategy: "debate" or promoted from solo)
 
-- **ACCEPT / TRIVIAL_ACCEPT**: update file-hash cache (`cache-update.sh`), update issue's `files` and `debates`. Sync plan tracking issue. If TRIVIAL_ACCEPT: note `fast_path: true`.
-- **CONDITIONAL_ACCEPT**: conditions resolved internally by debate-runner. Treat as consensus — update cache, files, debates. Log conditions for traceability. Sync plan tracking issue.
+- **ACCEPT / TRIVIAL_ACCEPT**: update file-hash cache (`cache-update.sh`), update issue's `files` and `debates`. Sync plan tracking issue. TRIVIAL_ACCEPT: note `fast_path: true`.
+- **CONDITIONAL_ACCEPT**: conditions resolved internally by debate-runner. Treat as consensus — update cache, files, debates. Log conditions. Sync plan tracking issue.
 - **Escalated (conditions_unresolved)**: follow escalation flow below.
 - **Escalated** (human escalation): update issue status, output early-exit summary (Step 5h), return.
 - **REGRESS**: handle via Step 5g.
 
 **[TodoWrite — Debate Results]**: Update phase item with verdict (e.g., `"Build phase — ACCEPT R1"`). Do not change phase status yet.
 
-**IMPORTANT**: Do NOT run debates yourself. For debate strategy, the debate-runner is the only path. For solo, the generative agent is spawned directly. If the agent cannot be spawned, halt and escalate.
-
-**IMPORTANT**: After processing debate results, proceed through ALL of Step 5f. Do NOT skip to next phase without packaging.
+**IMPORTANT**: Do NOT run debates yourself. For debate strategy, debate-runner is the only path; for solo, generative agent is spawned directly. If agent cannot be spawned, halt and escalate. After processing debate results, proceed through ALL of Step 5f — do NOT skip to next phase without packaging.
 
 #### 5f. Phase Gate — Guards and Advance
 
-**Check results:**
-- **Debate mode**: all consensus → guards; any escalated → early exit (Step 5h); any regress → Step 5g
-- **Solo mode**: all guards passed (already ran in 5e-solo) → phase advance; promoted → process debate results; failed → early exit (Step 5h)
+**Check results:** **Debate mode**: all consensus → guards; any escalated → early exit (Step 5h); any regress → Step 5g. **Solo mode**: all guards passed (already ran in 5e-solo) → phase advance; promoted → process debate results; failed → early exit (Step 5h).
 
-**Run post-execution guards** (debate mode only — solo already ran them in 5e-solo):
+**Run post-execution guards** (debate mode only — solo already ran them in 5e-solo). Invoke using **Guard Execution Pattern**. Results stored in `.ratchet/guards/<milestone-id>/<issue-ref>/<phase>/<guard-name>.json`. Blocking guard fails → `AskUserQuestion`: fix/override/view. Advisory guard fails → log and continue.
 
-Invoke using the **Guard Execution Pattern**. Guard results stored in `.ratchet/guards/<milestone-id>/<issue-ref>/<phase>/<guard-name>.json`.
-- Blocking guard fails → `AskUserQuestion`: fix/override/view
-- Advisory guard fails → log and continue
-
-**Advance phase:**
-- Mark current phase `done` in issue's `phase_status`
-- Auto-advance on fast-path (all TRIVIAL_ACCEPT) without confirmation
-- Next phase exists → set to `in_progress`, loop to Step 5a
-- All phases done → issue complete
-- Sync plan tracking issue after phase state change.
+**Advance phase:** Mark current phase `done` in issue's `phase_status`. Auto-advance on fast-path (all TRIVIAL_ACCEPT) without confirmation. Next phase exists → set to `in_progress`, loop to Step 5a. All phases done → issue complete. Sync plan tracking issue after phase state change.
 
 **[TodoWrite — Phase Complete]**: Set phase item to `"completed"` retaining verdict info.
 
-**Commit/PR is the orchestrator's responsibility, not the issue agent's.** The issue agent produces code in the worktree but does NOT commit, push, or create PRs. The worktree branch with uncommitted changes is the deliverable — the orchestrator handles packaging in Step 4c. This prevents depth-3+ agents from silently dropping the commit step.
+**Commit/PR is the orchestrator's responsibility, not the issue agent's.** The issue agent produces code in the worktree but does NOT commit, push, or create PRs. The worktree branch with uncommitted changes is the deliverable — orchestrator handles packaging in Step 4c. This prevents depth-3+ agents from silently dropping the commit step.
 
 #### 5g. Phase Regression
 
-> Solo mode: regression does not apply (no adversarial agent). If a promoted-to-debate issues REGRESS, handle normally below.
+> Solo mode: regression does not apply (no adversarial agent). If promoted-to-debate REGRESSes, handle normally below.
 
-When adversarial issues REGRESS targeting an earlier phase:
-1. Read `max_regressions` from config (default: 2), tracked per-milestone
-2. Budget exhausted → `AskUserQuestion`: allow/reject/escalate
-3. Within budget → increment counter, reset target phase and later to `pending`, set target to `in_progress`, preserve debate history, sync plan tracking issue, loop to Step 5a
+When adversarial issues REGRESS targeting an earlier phase: (1) read `max_regressions` from config (default: 2), tracked per-milestone; (2) budget exhausted → `AskUserQuestion`: allow/reject/escalate; (3) within budget → increment counter, reset target phase and later to `pending`, set target to `in_progress`, preserve debate history, sync plan tracking issue, loop to Step 5a.
 
 #### 5h. Issue Complete
 
-Set issue status to `done` in local plan.yaml (worktree copy — orchestrator writes authoritative update in Step 4c).
-
-**Output a structured completion summary as your final message.** The orchestrator parses this for Step 4c. The worktree is cleaned up after agent return, so this output is the only way results survive.
+Set issue status to `done` in local plan.yaml (worktree copy — orchestrator writes authoritative update in Step 4c). **Output structured completion summary as final message.** Orchestrator parses this for Step 4c. Worktree is cleaned up after agent return, so this output is the only way results survive.
 
 ```
 Issue [ref] [complete|blocked|escalated|failed]:
@@ -323,4 +269,4 @@ Field semantics:
 - `dependency_validation`: `passed` (pre-created, all files verified), `failed` (files missing/unmodified), `overridden` (failed but user overrode), `skipped` (isolation mode)
 - `executions`: execution log IDs from `.ratchet/executions/`. Empty for debate-only pipelines.
 
-This summary MUST be the last thing you output. The orchestrator reads plan.yaml for structured state, but this summary provides immediate human-readable feedback.
+Summary MUST be last output. Orchestrator reads plan.yaml for structured state, but this summary provides immediate human-readable feedback.

--- a/skills/run/modes/dry-run.md
+++ b/skills/run/modes/dry-run.md
@@ -1,10 +1,10 @@
 # Step 5-dry: Dry-Run Preview
 
-If `--dry-run` is specified, produce a formatted preview and stop. No agents are spawned, no debates created, no files modified.
+If `--dry-run` is specified, produce a formatted preview and stop. No agents spawned, no debates created, no files modified.
 
 ## Token Cost Estimation
 
-After building the dependency graph (Step 3), compute estimated tokens per issue using these formulas:
+After building dependency graph (Step 3), compute estimated tokens per issue:
 
 **Base tokens by pipeline mode:**
 | Pipeline mode | Base tokens | Phases | Rationale |
@@ -16,10 +16,7 @@ After building the dependency graph (Step 3), compute estimated tokens per issue
 | `standard` | 80k | plan, build, review, harden | Standard pipeline (4 phases) |
 | `full` | 160k | plan, test, build, review, harden | Full pipeline (5 phases) |
 
-**Scaling factors:**
-- **Pairs**: Multiply base by the number of pairs assigned to the issue. Each pair runs its own debate/execution.
-- **Guards**: Add 2k per guard (both pre-execution and post-execution) assigned to the issue's phases. Guards invoke external commands and produce output that consumes context.
-- **Max rounds** (debate mode only): The base already accounts for typical round counts. For `max_rounds > 3`, scale the debate portion by `max_rounds / 3`.
+**Scaling factors:** **Pairs** — multiply base by number of pairs assigned (each runs its own debate/execution). **Guards** — add 2k per guard (pre + post-execution) assigned to issue's phases (external commands consume context). **Max rounds** (debate mode only) — base accounts for typical counts; for `max_rounds > 3`, scale debate portion by `max_rounds / 3`.
 
 **Formula:**
 ```
@@ -32,10 +29,10 @@ where:
   guard_count  = number of guards matching the issue's component and phases
 ```
 
-**Cost estimation** uses current API rates (update these when rates change):
-- Opus input: $15 / 1M tokens, output: $75 / 1M tokens (assume 30% input, 70% output)
-- Sonnet input: $3 / 1M tokens, output: $15 / 1M tokens (assume 30% input, 70% output)
-- Debate mode uses both opus (generative) and sonnet (adversarial) — estimate 60% opus, 40% sonnet by token volume
+**Cost estimation** uses current API rates (update when rates change):
+- Opus: input $15/1M, output $75/1M (assume 30/70 input/output)
+- Sonnet: input $3/1M, output $15/1M (assume 30/70 input/output)
+- Debate mode uses opus (generative) + sonnet (adversarial) — estimate 60% opus, 40% sonnet by token volume
 - Solo mode uses opus only
 
 ```
@@ -89,9 +86,9 @@ Token & Cost Estimates
   Total                                 ~232k         ~$9.44
 ```
 
-**In `--unsupervised` mode**: Log the token and cost estimates to stdout but do not block execution. The estimates are informational — they help operators audit spend after the fact. Do not present the `AskUserQuestion` confirmation (unsupervised auto-selects "Run for real").
+**In `--unsupervised` mode**: Log token and cost estimates to stdout but do not block execution. Estimates are informational — help operators audit spend after the fact. Do not present `AskUserQuestion` confirmation (unsupervised auto-selects "Run for real").
 
-**In supervised mode**: Include the cost table in the `AskUserQuestion` confirmation:
+**In supervised mode**: Include cost table in `AskUserQuestion` confirmation:
 
 Question text:
 ```

--- a/skills/run/modes/epic-guided.md
+++ b/skills/run/modes/epic-guided.md
@@ -2,9 +2,7 @@
 
 ## Epic Complete Flow
 
-**If ALL milestones are done** (every milestone has `status: done`):
-
-The epic is complete. Present completion summary and next steps:
+**If ALL milestones are done** (every milestone has `status: done`), epic is complete. Present completion summary and next steps:
 
 Question text:
 ```
@@ -14,13 +12,13 @@ What would you like to do next?
 ```
 
 Options:
-- "Create a new epic" — gather details via AskUserQuestion (freeform: "What's the next body of work?"), then create the new epic structure in plan.yaml. For complex scoping, spawn the analyst agent to help break it into milestones. For straightforward requests, create directly from the user's description.
-- "Add a milestone to the current epic" — gather milestone details via AskUserQuestion, append to plan.yaml
+- "Create a new epic" — gather details via AskUserQuestion (freeform: "What's the next body of work?"), then create new epic structure in plan.yaml. For complex scoping, spawn analyst agent to break into milestones; for straightforward requests, create directly from user's description.
+- "Add a milestone to the current epic" — gather details via AskUserQuestion, append to plan.yaml
 - "Tighten agents from debate lessons (/ratchet:tighten)"
 - "View quality metrics (/ratchet:score)"
 - "Done for now"
 
-When creating a new epic: replace the existing `epic` block in plan.yaml (archive the old one to `.ratchet/archive/epic-<name>-<timestamp>.yaml` first if it has content). **Archive debates**: move all debate artifacts from the completed epic into the archive alongside the plan:
+When creating a new epic: replace existing `epic` block in plan.yaml (archive old one to `.ratchet/archive/epic-<name>-<timestamp>.yaml` first if it has content). **Archive debates**: move all debate artifacts from completed epic into archive alongside the plan:
 ```bash
 EPIC_SLUG=$(echo "$EPIC_NAME" | tr ' ' '-' | tr '[:upper:]' '[:lower:]')
 ARCHIVE_DIR=".ratchet/archive/epic-${EPIC_SLUG}-$(date +%Y%m%dT%H%M%SZ)"
@@ -30,9 +28,9 @@ if [ -d .ratchet/debates ] && [ "$(ls -A .ratchet/debates 2>/dev/null)" ]; then
   mv .ratchet/debates/* "$ARCHIVE_DIR/debates/" 2>/dev/null || true
 fi
 ```
-This is safe because `/ratchet:score` persists metrics as a moving average in `.ratchet/scores.yaml` (Step 2b of the score skill) — archiving debates does not lose score history.
+Safe because `/ratchet:score` persists metrics as moving average in `.ratchet/scores.yaml` (Step 2b of score skill) — archiving debates does not lose score history.
 
-Set `current_focus: null` and `discoveries: []` (or carry over pending discoveries). After writing the new epic to plan.yaml, sync the tracking issue:
+Set `current_focus: null` and `discoveries: []` (or carry over pending). After writing the new epic to plan.yaml, sync tracking issue:
 ```bash
 if [ -f .claude/ratchet-scripts/progress/github-issues/sync-plan.sh ]; then
   bash .claude/ratchet-scripts/progress/github-issues/sync-plan.sh \
@@ -42,7 +40,7 @@ fi
 
 ## Focus Selection (milestones remain)
 
-Use `AskUserQuestion` to let the user pick the focus. Include epic status with per-issue progress:
+Use `AskUserQuestion` to let user pick focus. Include epic status with per-issue progress:
 
 Question text (build from plan.yaml):
 ```
@@ -75,26 +73,21 @@ Options:
 - "Add a new milestone" — gather details via AskUserQuestion, append to plan.yaml, then offer to run it
 - "[Next milestone name]" — skip ahead
 - "Review all existing code"
-- (Include an "Other" option so the user can type a custom focus)
+- (Include "Other" option so user can type a custom focus)
 
 ## Sidequest Processing
 
-When "Process sidequests" is selected, iterate over `epic.discoveries` with `status == "pending"`. For each discovery, use `AskUserQuestion`:
+When "Process sidequests" selected, iterate over `epic.discoveries` with `status == "pending"`. For each, use `AskUserQuestion`:
 
 - Question: "Discovery: [title] ([category], [severity])\n[description]"
-- Options:
-  - `"Process now"` — handle via existing pipeline (tighten, re-launch, etc.)
-  - `"Promote to issue"` — convert this discovery into a full plan.yaml issue
-  - `"Dismiss"` — mark as non-actionable
-  - `"Skip for now"` — leave as pending, move to next discovery
+- Options: `"Process now"` (handle via existing pipeline — tighten, re-launch, etc.), `"Promote to issue"` (convert to full plan.yaml issue), `"Dismiss"` (mark non-actionable), `"Skip for now"` (leave pending, move to next)
 
 ### Action: Process now
 
-Existing behavior:
-- `retro_type: "ci-failure"` → extract PR number from `source` field (format: `pr-ci-failure-<N>`) and launch `/ratchet:tighten pr <N>` for the affected issue
-- `retro_type: "skipped-finding"` → present to user for decision (apply now or defer)
-- No `retro_type` with `issue_ref` set (merge conflict) → use `issue_ref` field directly to re-launch the issue pipeline in its current phase
-- No `retro_type` with `issue_ref: null` (manual discovery with no issue context) → cannot process directly, inform user: "This discovery has no linked issue. Promote it to an issue first, or dismiss it." Then re-present the action selector without the "Process now" option.
+- `retro_type: "ci-failure"` → extract PR number from `source` field (format: `pr-ci-failure-<N>`) and launch `/ratchet:tighten pr <N>`
+- `retro_type: "skipped-finding"` → present to user (apply now or defer)
+- No `retro_type` with `issue_ref` set (merge conflict) → use `issue_ref` to re-launch issue pipeline in current phase
+- No `retro_type` with `issue_ref: null` (manual discovery) → cannot process directly. Inform user: "This discovery has no linked issue. Promote it to an issue first, or dismiss it." Then re-present action selector without "Process now" option.
 - Mark each processed discovery `status: "done"` in `plan.yaml`:
   ```bash
   yq eval -i "(.epic.discoveries[] | select(.ref == \"$discovery_ref\")).status = \"done\"" .ratchet/plan.yaml
@@ -109,14 +102,10 @@ Existing behavior:
 
 ### Action: Promote to issue
 
-Converts a discovery into a full plan.yaml issue:
-1. Determine target milestone:
-   - If `context.milestone` is set, use that milestone
-   - Otherwise, use `AskUserQuestion` to select from active milestones
-2. Generate issue ref: read existing issues in the target milestone, find the highest issue number, increment by 1. Format: `issue-<milestone-number>-<next-issue-number>`
-3. Determine pairs:
-   - If discovery `pairs` array is non-empty, use those
-   - Otherwise, use `AskUserQuestion` to select from available pairs in workflow.yaml
+Converts discovery into a full plan.yaml issue:
+1. Target milestone: if `context.milestone` set, use it; else `AskUserQuestion` to select from active milestones
+2. Generate issue ref: find highest issue number in target milestone, increment by 1. Format: `issue-<milestone-number>-<next-issue-number>`
+3. Pairs: if discovery `pairs` array non-empty, use those; else `AskUserQuestion` to select from available pairs in workflow.yaml
 4. Create the issue entry in plan.yaml:
    ```bash
    new_ref="issue-<M>-<N>"
@@ -134,7 +123,7 @@ Converts a discovery into a full plan.yaml issue:
      \"status\": \"pending\"
    }])" .ratchet/plan.yaml
    ```
-5. Update the discovery status and link:
+5. Update discovery status and link:
    ```bash
    yq eval -i "(.epic.discoveries[] | select(.ref == \"$discovery_ref\")).status = \"promoted\"" .ratchet/plan.yaml
    yq eval -i "(.epic.discoveries[] | select(.ref == \"$discovery_ref\")).issue_ref = \"$new_ref\"" .ratchet/plan.yaml
@@ -150,8 +139,8 @@ Converts a discovery into a full plan.yaml issue:
 
 ### Action: Dismiss
 
-Marks a discovery as non-actionable:
-1. Use `AskUserQuestion` (freeform): "Reason for dismissal (optional)"
+Marks discovery as non-actionable:
+1. `AskUserQuestion` (freeform): "Reason for dismissal (optional)"
 2. Update plan.yaml:
    ```bash
    yq eval -i "(.epic.discoveries[] | select(.ref == \"$discovery_ref\")).status = \"dismissed\"" .ratchet/plan.yaml

--- a/skills/run/modes/here.md
+++ b/skills/run/modes/here.md
@@ -1,51 +1,29 @@
 # --here Modifier (in-session execution)
 
-`--here` is a **modifier**, not a mode. It modifies how the resolved mode executes
-by keeping all work in the current session — no worktree isolation, no agent
-spawning. The human is interactively present and serves as the quality gate.
+`--here` is a **modifier**, not a mode. Modifies how the resolved mode executes by keeping all work in the current session — no worktree isolation, no agent spawning. Human is interactively present and serves as quality gate.
 
-**Restriction:** `--here` is valid ONLY in top-level human-interactive sessions.
-Spawned agents (issue pipelines, debate-runners, continuation agents) MUST NOT
-claim `--here`. If a spawned agent receives `--here`, it MUST ignore the flag
-and execute normally.
+**Restriction:** `--here` is valid ONLY in top-level human-interactive sessions. Spawned agents (issue pipelines, debate-runners, continuation agents) MUST NOT claim `--here`. If a spawned agent receives `--here`, it MUST ignore the flag and execute normally.
 
 **Forbidden combinations:**
-- `--here --unsupervised` → FORBIDDEN. In-session execution requires human presence;
-  unsupervised mode removes it. If both are passed, halt with error:
-  `"--here and --unsupervised are mutually exclusive. --here requires human interaction."`
-- `--here --go` → FORBIDDEN (since `--go` is shorthand for `--unsupervised --auto-pr`).
-  Same error as above.
+- `--here --unsupervised` → FORBIDDEN. In-session execution requires human presence; unsupervised mode removes it. If both passed, halt with error: `"--here and --unsupervised are mutually exclusive. --here requires human interaction."`
+- `--here --go` → FORBIDDEN (since `--go` is shorthand for `--unsupervised --auto-pr`). Same error as above.
 
 **Allowed combinations and behavior:**
-- `--here --quick "<desc>"` → Follows Mode Q behavior (single generative pass,
-  auto-commit). The orchestrator executes the generative work directly in the
-  current session instead of spawning a generative agent. Auto-commits on
-  completion (Mode Q behavior).
-- `--here --auto-pr` → Auto-commit all changes and create a PR without prompting.
-  No `AskUserQuestion` for the commit step.
-- `--here --issue <ref>` → Execute the issue's pipeline in the current session
-  on the current branch. Skip worktree creation. Read the issue's phase_status
-  from plan.yaml and execute the current phase directly.
-- `--here` (alone, no other mode flag) → Read plan.yaml normally (Step 1b),
-  determine focus (Step 2), then execute directly in the current session.
+- `--here --quick "<desc>"` → Follows Mode Q behavior (single generative pass, auto-commit). Orchestrator executes generative work directly in current session instead of spawning a generative agent. Auto-commits on completion.
+- `--here --auto-pr` → Auto-commit all changes and create PR without prompting. No `AskUserQuestion` for commit step.
+- `--here --issue <ref>` → Execute issue's pipeline in current session on current branch. Skip worktree creation. Read issue's phase_status from plan.yaml and execute current phase directly.
+- `--here` (alone, no other mode flag) → Read plan.yaml normally (Step 1b), determine focus (Step 2), execute directly in current session.
 
 **How `--here` modifies execution:**
 
-1. **No worktree isolation**: Work happens on the current branch. No `isolation: "worktree"`
-   on Agent tool calls (because no Agent tool calls are made).
-2. **No agent spawning**: The orchestrator performs the generative work directly.
-   The AGENT GATE is bypassed — the orchestrator MAY use Write and Edit on source
-   files. The Source Code Boundary carve-out applies.
-3. **Guards**: Run guards with `milestone-id=0` and `phase=build` when no
-   milestone/phase context exists (e.g., `--here` alone without `--issue`).
-   When context exists (e.g., `--here --issue <ref>`), use the actual
-   milestone ID and current phase.
-4. **Plan.yaml**: Read normally (Step 1b). Skip only with `--here --quick`
-   (Mode Q skips plan.yaml regardless).
+1. **No worktree isolation**: Work happens on current branch. No `isolation: "worktree"` on Agent tool calls (because no Agent tool calls are made).
+2. **No agent spawning**: Orchestrator performs generative work directly. AGENT GATE is bypassed — orchestrator MAY use Write and Edit on source files. Source Code Boundary carve-out applies.
+3. **Guards**: Run guards with `milestone-id=0` and `phase=build` when no milestone/phase context exists (e.g., `--here` alone without `--issue`). When context exists (e.g., `--here --issue <ref>`), use actual milestone ID and current phase.
+4. **Plan.yaml**: Read normally (Step 1b). Skip only with `--here --quick` (Mode Q skips plan.yaml regardless).
 5. **Commit behavior**:
    - `--here --quick`: Auto-commit (Mode Q behavior).
    - `--here --auto-pr`: Auto-commit + auto-PR (no prompt).
-   - `--here` alone: Prompt the user via `AskUserQuestion`:
+   - `--here` alone: Prompt user via `AskUserQuestion`:
      ```
      Changes complete. What would you like to do?
      ```

--- a/skills/run/modes/quick-fix.md
+++ b/skills/run/modes/quick-fix.md
@@ -1,26 +1,20 @@
 # Mode Q: Quick-fix (`--quick "<description>"`)
 
-If `--quick` is set, skip `plan.yaml` entirely. This mode is a fast path for small, well-understood fixes that don't need epic/milestone/issue management or adversarial review.
-
-**Checked first** — before all other modes. If `--quick` is present, no other mode flags are evaluated.
+If `--quick` is set, skip `plan.yaml` entirely. Fast path for small, well-understood fixes that don't need epic/milestone/issue management or adversarial review. **Checked first** — before all other modes. If `--quick` is present, no other mode flags are evaluated.
 
 **Flag interactions:**
-- `--quick --dry-run`: Print the detected component, scope, and guards that would run, then stop. No agent spawned, no changes made.
-- `--quick --auto-pr`: Create a branch and PR after the commit (see step 5).
-- `--quick --unsupervised`: If component auto-detection fails, halt with error. If a guard fails, halt with `failed` (no retry).
+- `--quick --dry-run`: Print detected component, scope, guards that would run, then stop. No agent spawned, no changes made.
+- `--quick --auto-pr`: Create branch and PR after commit (see step 5).
+- `--quick --unsupervised`: If component auto-detection fails, halt with error. If guard fails, halt with `failed` (no retry).
 - `--quick --no-cache`: No effect — Mode Q has no file-hash cache.
 
-**1. Parse description:**
-
-The freeform `<description>` argument is the task. It should describe what to do and which files are involved:
+**1. Parse description:** The freeform `<description>` argument is the task. Should describe what to do and which files are involved:
 ```
 /ratchet:run --quick "Fix off-by-one in src/parser.ts validateToken loop"
 /ratchet:run --quick "Add missing error handling to scripts/deploy.sh"
 ```
 
-**2. Auto-detect component from file paths:**
-
-Extract file paths from the description (tokens matching known file extensions or path separators):
+**2. Auto-detect component from file paths:** Extract file paths from the description (tokens matching known file extensions or path separators):
 ```bash
 # Extract candidate paths from the description
 PATHS=$(echo "$DESCRIPTION" | grep -oE '[a-zA-Z0-9_./-]+\.[a-zA-Z]{1,10}' | sort -u)
@@ -35,15 +29,9 @@ for path in $PATHS; do
 done
 ```
 
-If no file paths are detected or no component matches, use `AskUserQuestion`:
-- Question: "Could not auto-detect component from the description. Which component?"
-- Options: one per component in `workflow.yaml`, plus `"Cancel"`
+If no file paths detected or no component matches, use `AskUserQuestion`: "Could not auto-detect component from the description. Which component?" Options: one per component in `workflow.yaml`, plus `"Cancel"`. In unsupervised mode with no component match: halt with error — quick-fix requires detectable scope.
 
-In unsupervised mode with no component match: halt with error — quick-fix requires a detectable scope.
-
-**3. Spawn one generative agent:**
-
-Spawn a single generative agent (using the resolved `generative` model) with the description as the prompt. The agent receives build-phase constraints (it can read, write, and edit files within the detected component's scope):
+**3. Spawn one generative agent:** Spawn a single generative agent (using resolved `generative` model) with the description as prompt. Agent receives build-phase constraints (read, write, edit files within detected component's scope):
 
 ```
 Quick-fix mode — single generative pass.
@@ -63,13 +51,9 @@ PRINCIPLE — Guilty Until Proven Innocent:
   unless you can prove otherwise on a clean checkout.
 ```
 
-**Tool boundaries for the quick-fix generative agent:**
-- tools: Read, Grep, Glob, Bash, Write, Edit
-- Same as debate-mode generative agent — the only difference is no adversarial review and no debate structure
+**Tool boundaries** (same as debate-mode generative agent — only difference: no adversarial review, no debate structure): Read, Grep, Glob, Bash, Write, Edit
 
-**4. Run blocking guards:**
-
-After the generative agent returns, run all blocking guards for the detected component's phase (use `review` phase guards as default):
+**4. Run blocking guards:** After generative agent returns, run all blocking guards for detected component's phase (use `review` phase guards as default):
 
 ```bash
 test -f .claude/ratchet-scripts/run-guards.sh \
@@ -78,31 +62,25 @@ test -f .claude/ratchet-scripts/run-guards.sh \
 bash .claude/ratchet-scripts/run-guards.sh quick-fix review <guard-name> "<guard-command>" true
 ```
 
-- If any blocking guard fails:
-  - **Guilty until proven innocent**: the quick-fix caused it. Verify on clean master before dismissing.
-  - In supervised mode: use `AskUserQuestion`: "Guard '[name]' failed: [summary]."
-    - Options: `"Fix and re-run"`, `"Abort quick-fix"`, `"Override guard"`
-  - In unsupervised mode: halt with status `failed` — quick-fix does not retry automatically.
+- If any blocking guard fails: **Guilty until proven innocent** — the quick-fix caused it. Verify on clean master before dismissing.
+  - Supervised: `AskUserQuestion`: "Guard '[name]' failed: [summary]." Options: `"Fix and re-run"`, `"Abort quick-fix"`, `"Override guard"`
+  - Unsupervised: halt with status `failed` — quick-fix does not retry automatically.
 - Advisory guards: log and continue.
 
-**5. Commit and optionally create PR:**
-
-If all blocking guards pass, commit with a message derived from the description.
-
-If `--auto-pr` is also set, create a branch first:
+**5. Commit and optionally create PR:** If all blocking guards pass, commit with a message derived from the description. If `--auto-pr` is also set, create a branch first:
 ```bash
 # Create branch before committing (only with --auto-pr)
 BRANCH="ratchet/quick-fix/$(echo "$DESCRIPTION" | tr ' ' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-50)"
 git checkout -b "$BRANCH"
 ```
 
-Then commit (on the new branch if `--auto-pr`, or the current branch otherwise):
+Then commit (on new branch if `--auto-pr`, else current branch):
 ```bash
 git add -A
 git commit -m "<description>"
 ```
 
-If `--auto-pr` is set, push and create the PR:
+If `--auto-pr` is set, push and create PR:
 ```bash
 git push -u origin "$BRANCH"
 gh pr create --title "$DESCRIPTION" --body "Quick-fix via \`/ratchet:run --quick\`"
@@ -126,11 +104,9 @@ files_modified: [<files>]
 EOF
 ```
 
-**7. Skip epic/milestone/issue management:**
+**7. Skip epic/milestone/issue management:** Mode Q does not read or write `plan.yaml`. No milestone, issue, or phase tracking. No debate artifacts. Commit is local unless `--auto-pr` creates a branch and PR (see step 5).
 
-Mode Q does not read or write `plan.yaml`. No milestone, issue, or phase tracking. No debate artifacts. The commit is local unless `--auto-pr` creates a branch and PR (see step 5).
-
-> **Note on Step 1**: Mode Q still requires Step 1a (workspace resolution) to locate `workflow.yaml` for component auto-detection. However, Step 1b's `plan.yaml` reading is skipped entirely — Mode Q has no concept of milestones, issues, or phases.
+> **Note on Step 1**: Mode Q still requires Step 1a (workspace resolution) to locate `workflow.yaml` for component auto-detection. Step 1b's `plan.yaml` reading is skipped entirely — Mode Q has no concept of milestones, issues, or phases.
 
 **8. Output summary:**
 

--- a/skills/run/plan-tracking-format.md
+++ b/skills/run/plan-tracking-format.md
@@ -1,20 +1,14 @@
 # GitHub Plan Tracking Issue Format
 
-> This file is the extracted plan tracking issue format spec from `skills/run/SKILL.md`.
-> It is loaded on demand when the orchestrator interacts with the GitHub plan tracking issue.
-> For the orchestrator flow, see `skills/run/SKILL.md`.
+> Extracted plan tracking issue format spec from `skills/run/SKILL.md`. Loaded on demand when orchestrator interacts with GitHub plan tracking issue. For orchestrator flow, see `skills/run/SKILL.md`.
 
 ---
 
 ## GitHub Plan Tracking Issue
 
-When the `github-issues` progress adapter is enabled, a single GitHub issue mirrors
-`plan.yaml` as a human-readable roadmap. This tracking issue serves as a backup for
-`plan.yaml` and enables deterministic recovery without LLM assistance.
+When `github-issues` progress adapter is enabled, a single GitHub issue mirrors `plan.yaml` as human-readable roadmap. Serves as backup for `plan.yaml` and enables deterministic recovery without LLM assistance.
 
-**Canonical body format:**
-
-The tracking issue body has two layers: human-readable markdown (visible on GitHub) and hidden HTML comment metadata (for machine parsing). All HTML comments MUST be single-line — multi-line comments render as visible text on GitHub.
+**Canonical body format:** Two layers — human-readable markdown (visible on GitHub) and hidden HTML comment metadata (for machine parsing). All HTML comments MUST be single-line — multi-line comments render as visible text on GitHub.
 
 ```markdown
 <!-- ratchet-plan-tracking -->
@@ -68,14 +62,14 @@ Feature complete and reviewed
 <!-- issue_pr: null -->
 ```
 
-**Critical rendering rule:** All JSON values inside HTML comments (`issue_pairs`, `issue_depends_on`, `issue_phase_status`, `milestone_depends_on`) MUST be compact single-line JSON. Multi-line JSON like `[\n  "foo"\n]` breaks GitHub's comment hiding and renders as visible text. The `sync-plan.sh` script uses `compact_json()` to enforce this.
+**Critical rendering rule:** All JSON values inside HTML comments (`issue_pairs`, `issue_depends_on`, `issue_phase_status`, `milestone_depends_on`) MUST be compact single-line JSON. Multi-line JSON like `[\n  "foo"\n]` breaks GitHub's comment hiding and renders as visible text. `sync-plan.sh` uses `compact_json()` to enforce this.
 
 **HTML comment metadata rules:**
 - Every milestone block MUST have `milestone_id`, `milestone_status`, `milestone_done_when`, `milestone_depends_on`
 - Every issue block MUST have `issue_ref`, `issue_status`, `issue_pairs`, `issue_depends_on`, `issue_phase_status`, `issue_branch`, `issue_pr`, `issue_progress_ref`
 - The `<!-- ratchet-plan-tracking -->` sentinel on line 1 identifies the issue for deterministic parsing
 - Checkbox state (`[x]` vs `[ ]`) reflects `issue_status == "done"` but is NOT the parse source — `issue_status` in the HTML comment is authoritative
-- Fields NOT stored (not recoverable from tracking issue): `files`, `debates` arrays — these are runtime artifacts
+- Fields NOT stored (not recoverable from tracking issue): `files`, `debates` arrays — runtime artifacts
 
 **Sync helper — existence-guarded call pattern:**
 ```bash

--- a/skills/run/pr-body.md
+++ b/skills/run/pr-body.md
@@ -1,14 +1,12 @@
 # PR Body and Debate Summary Builder
 
-> This file is the extracted PR body construction logic from `skills/run/issue-pipeline.md`.
-> It is loaded on demand when the issue pipeline creates a PR at commit/PR boundaries (Step 5f).
-> For the full issue pipeline, see `skills/run/issue-pipeline.md`.
+> Extracted PR body construction logic from `skills/run/issue-pipeline.md`. Loaded on demand when issue pipeline creates a PR at commit/PR boundaries (Step 5f). For full pipeline, see `skills/run/issue-pipeline.md`.
 
 ---
 
 ## Building the Debate Summary Section
 
-The issue pipeline tracks debate IDs in the issue's `debates` array in plan.yaml (recorded by the debate-runner via `yq` after each debate completes). Read them at PR creation time:
+The pipeline tracks debate IDs in the issue's `debates` array in plan.yaml (recorded by debate-runner via `yq` after each debate completes). Read at PR creation time:
 
 ```bash
 # Step 1: Read debate IDs from the issue's debates array in plan.yaml
@@ -127,6 +125,6 @@ gh pr create \
 **Rules:**
 - Data sourced exclusively from `meta.json` `conditions` array — do NOT summarize adversarial narrative or round text
 - Conditions block only shown when at least one `CONDITIONAL_ACCEPT` verdict exists (`$has_conditional = true`)
-- If `meta.json` is missing or unreadable for a debate ID, skip that row and log a warning: `"Warning: could not load debate metadata for [id]"` to stderr
+- If `meta.json` is missing/unreadable, skip that row and log: `"Warning: could not load debate metadata for [id]"` to stderr
 - Section omitted entirely when `debates` array is empty (`${#debate_ids[@]} -eq 0`)
-- Multiple debates -> multiple table rows; a debate with no conditions contributes no lines to the conditions block
+- Multiple debates -> multiple table rows; a debate with no conditions contributes no lines to conditions block

--- a/skills/run/unsupervised.md
+++ b/skills/run/unsupervised.md
@@ -1,63 +1,51 @@
 # Unsupervised Mode
 
-> This file is the extracted Unsupervised Mode section from `skills/run/SKILL.md`.
-> It is loaded on demand when `--unsupervised` is passed to `/ratchet:run`.
-> For the main orchestrator flow, see `skills/run/SKILL.md`.
+> Extracted Unsupervised Mode section from `skills/run/SKILL.md`. Loaded on demand when `--unsupervised` is passed to `/ratchet:run`. For main orchestrator flow, see `skills/run/SKILL.md`.
 
 ---
 
-When `--unsupervised` is set, the run loop executes the entire plan (all milestones, all phases) without human interaction. The principle is simple: **wherever an `AskUserQuestion` has a "(Recommended)" option, auto-select it.**
+When `--unsupervised` is set, the run loop executes the entire plan (all milestones, all phases) without human interaction. Principle: **wherever an `AskUserQuestion` has a "(Recommended)" option, auto-select it.**
 
-> **`--go` flag**: `--go` is shorthand for `--unsupervised --auto-pr`. It is equivalent in every way — the same behavior, halt conditions, and self-continuation rules apply.
+> **`--go` flag**: shorthand for `--unsupervised --auto-pr`. Equivalent in every way.
 
 ## Behavior
 
-- **Step 1a (workspace)**: If at workspace root with no workspace specified, **halt** — unsupervised mode requires an explicit workspace target (`/ratchet:run --unsupervised monitor`). Auto-selecting a workspace is too risky.
-- **Step 1c (orphan detection)**: Auto-select based on finding age: Abandon for stale items (>24h or unknown age), Resume for recent items (<4h), Ignore for ambiguous (4-24h). See Step 1c in SKILL.md for the full decision matrix.
-- **Step 2 (focus)**: Auto-select "Run all ready issues sequentially" for the current milestone. When a milestone completes, auto-advance to the next. In DAG mode, auto-launch all ready milestones in parallel.
+- **Step 1a (workspace)**: If at workspace root with no workspace specified, **halt** — unsupervised mode requires explicit workspace target (`/ratchet:run --unsupervised monitor`). Auto-selecting a workspace is too risky.
+- **Step 1c (orphan detection)**: Auto-select based on finding age: Abandon for stale items (>24h or unknown age), Resume for recent items (<4h), Ignore for ambiguous (4-24h). See Step 1c in SKILL.md for full decision matrix.
+- **Step 2 (focus)**: Auto-select "Run all ready issues sequentially" for current milestone. When a milestone completes, auto-advance to next. In DAG mode, auto-launch all ready milestones in parallel.
 - **Step 4 (issue pipelines)**: Execute all ready issues sequentially inline. Each issue pipeline runs in an isolated worktree, spawning only debate-runner agents.
-- **Step 5-dry (dry-run)**: Dry-run takes precedence — produce the preview (including token and cost estimates), log the estimates to stdout, and stop. No agents are spawned. The `AskUserQuestion` confirmation is skipped (estimates are informational only).
-- **Step 5c (pre-debate guards)**: If a blocking pre-debate guard fails → auto-select "Fix and re-run". The generative agent attempts to fix the issue. If the fix fails after 2 attempts, that issue **halts** (other issues continue).
+- **Step 5-dry (dry-run)**: Dry-run takes precedence — produce preview (including token and cost estimates), log estimates to stdout, stop. No agents spawned. The `AskUserQuestion` confirmation is skipped (estimates are informational only).
+- **Step 5c (pre-debate guards)**: If a blocking pre-debate guard fails → auto-select "Fix and re-run". Generative agent attempts to fix. If fix fails after 2 attempts, that issue **halts** (other issues continue).
 - **Step 6 (static analysis)**: Auto-select "Fix these before running". Same 2-attempt retry, then halt.
 - **Step 5e (debates)**: Run normally. Debates are autonomous by nature. If debate-runner cannot be spawned (tool unavailable), the issue **halts** with status `blocked` — quality gates cannot be compromised.
-- **Step 5e (escalation)**: If escalation policy is `tiebreaker` or `both`, auto-escalate to tiebreaker. If policy is `human`, that issue **halts** — this is the primary stop condition.
+- **Step 5e (escalation)**: If escalation policy is `tiebreaker` or `both`, auto-escalate to tiebreaker. If policy is `human`, that issue **halts** — primary stop condition.
 - **Step 5e (precedent)**: Auto-select "Apply settled pattern" when available.
 - **Step 5f (post-debate guards)**: If blocking guard fails → auto-select "Fix and re-run" (2 attempts, then halt issue).
 - **Step 5f (advance)**: Auto-advance to next phase. No user confirmation needed.
-- **Step 5f (commit/PR)**: Auto-select "Commit locally" by default. If `--auto-pr` is also set, auto-select "Create a pull request" instead — the human pre-approved this by passing the flag.
+- **Step 5f (commit/PR)**: Auto-select "Commit locally" by default. If `--auto-pr` is also set, auto-select "Create a pull request" instead — human pre-approved this by passing the flag.
 - **Step 5g (regression)**: If within budget, auto-regress. If budget exhausted, **halt** issue.
 - **Step 8c (analyst assessment)**: Auto-select "Note for later" — don't halt for advisory feedback.
-- **Step 10 (next focus)**: Do not present options. Instead, use the **self-continuation mechanism** (see below).
+- **Step 10 (next focus)**: Do not present options. Use the **self-continuation mechanism** (see below).
 - **Milestone re-opening guard (Step 3)**: Never auto-reopen done milestones. **Halt** and report.
 
 ## Self-Continuation via Agent Tool
 
-The unsupervised loop is driven by `plan.yaml` as a state machine and the Agent tool as the continuation mechanism.
-
-At **Step 10**, if `--unsupervised` is set and no halt condition was triggered:
+Unsupervised loop is driven by `plan.yaml` as state machine and Agent tool as continuation mechanism. At **Step 10**, if `--unsupervised` is set and no halt condition triggered:
 1. Write all state to `plan.yaml` (phase_status, current_focus, regressions, etc.)
-2. Spawn a new agent via the Agent tool with the task: `/ratchet:run --unsupervised`
-3. The spawned agent reads `plan.yaml`, finds the next pending phase/milestone, and continues from Step 1
+2. Spawn new agent via Agent tool with task: `/ratchet:run --unsupervised`
+3. Spawned agent reads `plan.yaml`, finds next pending phase/milestone, continues from Step 1
 
-This creates a chain: each agent handles one milestone, persists state, and spawns the next. `plan.yaml` is the continuity mechanism — if the session crashes at any point, a manual `/ratchet:run --unsupervised` picks up from the last persisted state.
+Creates a chain: each agent handles one milestone, persists state, spawns next. `plan.yaml` is the continuity mechanism — if session crashes, manual `/ratchet:run --unsupervised` picks up from last persisted state.
 
-**Context clearing at milestone boundaries**: Self-continuation MUST happen at milestone boundaries — the spawned agent starts with a fresh context and re-reads all state from disk. This prevents context drift from auto-compaction summaries corrupting downstream work. Within a milestone, phases run in the same context (cross-phase continuity has value). Between milestones, fresh context forces the agent to rely on persisted state (plan.yaml, debate transcripts, scores) rather than compressed memories.
+**Context clearing at milestone boundaries**: Self-continuation MUST happen at milestone boundaries — spawned agent starts with fresh context and re-reads state from disk. Prevents context drift from auto-compaction summaries corrupting downstream work. Within a milestone, phases run in same context (cross-phase continuity has value). Between milestones, fresh context forces reliance on persisted state (plan.yaml, debate transcripts, scores) rather than compressed memories.
 
-**Why Agent tool, not a shell loop**: Agents start with fresh context, can read/write project files, and the state machine (`plan.yaml`) handles crash recovery naturally. No external tooling or hook configuration required.
+**Why Agent tool, not a shell loop**: Agents start with fresh context, can read/write project files, and state machine (`plan.yaml`) handles crash recovery naturally. No external tooling or hook configuration required.
 
 ## Halt Conditions
 
-**Issue-level halts** (the issue stops, other issues continue):
-1. A debate requires human escalation (`escalation: human`)
-2. Debate-runner cannot be spawned (tool unavailable) — quality gate cannot be enforced
-3. A blocking guard fails after 2 auto-fix attempts
-4. Regression budget is exhausted and no auto-resolution is possible
+**Issue-level halts** (issue stops, others continue): (1) debate requires human escalation (`escalation: human`); (2) debate-runner cannot be spawned (tool unavailable) — quality gate cannot be enforced; (3) blocking guard fails after 2 auto-fix attempts; (4) regression budget exhausted and no auto-resolution possible.
 
-**Milestone-level halts** (the entire run stops):
-5. A static analysis pre-gate fails after 2 attempts (Step 6)
-6. A done milestone would need re-opening
-7. All issues in the milestone are halted (no progress possible)
-8. All milestones are complete (success)
+**Milestone-level halts** (entire run stops): (5) static analysis pre-gate fails after 2 attempts (Step 6); (6) a done milestone would need re-opening; (7) all issues in milestone are halted (no progress); (8) all milestones complete (success).
 
 On halt, present a summary:
 ```
@@ -82,13 +70,9 @@ Unsupervised run [completed|paused]:
 - `--unsupervised --dry-run`: Dry-run takes precedence (preview only, no execution)
 - `--go --no-cache`: Combines `--go` with `--no-cache` (force re-debate, unsupervised, auto-PR)
 - `--go --all-files`: Combines `--go` with `--all-files` (all pairs, unsupervised, auto-PR)
-- `--quick "<description>"`: Compatible with `--unsupervised`. In unsupervised mode, if component auto-detection fails, Mode Q halts with error (no interactive fallback). If a blocking guard fails, Mode Q halts with status `failed` (no retry). Combinable with `--auto-pr` to auto-create a branch and PR from the quick-fix commit.
+- `--quick "<description>"`: Compatible with `--unsupervised`. In unsupervised mode, if component auto-detection fails, Mode Q halts with error (no interactive fallback). If a blocking guard fails, Mode Q halts with status `failed` (no retry). Combinable with `--auto-pr` to auto-create branch and PR from the quick-fix commit.
 
 ## Forbidden Combinations
 
-- **`--here --unsupervised`**: FORBIDDEN. `--here` requires human-interactive presence;
-  `--unsupervised` removes human interaction. These are mutually exclusive by design.
-  If both are passed, halt immediately with error:
-  `"--here and --unsupervised are mutually exclusive. --here requires human interaction."`
-- **`--here --go`**: FORBIDDEN. `--go` is shorthand for `--unsupervised --auto-pr`,
-  so this reduces to the `--here --unsupervised` case above. Same error message.
+- **`--here --unsupervised`**: FORBIDDEN. `--here` requires human-interactive presence; `--unsupervised` removes human interaction. Mutually exclusive by design. If both passed, halt immediately with error: `"--here and --unsupervised are mutually exclusive. --here requires human interaction."`
+- **`--here --go`**: FORBIDDEN. `--go` is shorthand for `--unsupervised --auto-pr`, reducing to the `--here --unsupervised` case above. Same error message.


### PR DESCRIPTION
## Summary

Apply caveman compression to 8 helper files under `skills/run/`.

| File | Before | After | Reduction |
|------|--------|-------|-----------|
| issue-pipeline.md | 326 | 272 | −16.6% |
| unsupervised.md | 94 | 78 | −17.0% |
| pr-body.md | 132 | 130 | −1.5% |
| plan-tracking-format.md | 87 | 81 | −6.9% |
| modes/dry-run.md | 105 | 102 | −2.9% |
| modes/epic-guided.md | 163 | 152 | −6.7% |
| modes/here.md | 67 | 45 | −32.8% |
| modes/quick-fix.md | 147 | 123 | −16.3% |

**Total: 1121 → 983 (−12.3%)**

Variance explained: pr-body.md and dry-run.md are dominated by bash + ASCII tables + YAML (all preserved byte-identical). Files with more prose (issue-pipeline, unsupervised, here, quick-fix) hit 15-33%.

## Verified preserved
- All code fences balanced and matching original counts
- All 26 HTML comments in plan-tracking-format.md preserved
- File paths, inline code, headings, frontmatter, verdict keywords intact

## Milestone
M3: Caveman compression — large skills + run helpers