### PR TITLE
Track ratchet institutional memory in VCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,33 +2,53 @@ result
 result-*
 .claude/ratchet-scripts/
 
-# Ratchet: Exclude all runtime state, then include config
+# Ratchet: Exclude all runtime state, then whitelist institutional memory.
+#
+# Philosophy: low-churn, high-value artifacts that agents need on a fresh
+# clone get tracked. High-churn or noisy runtime state stays excluded.
 .ratchet/*
 !.ratchet/workflow.yaml
 !.ratchet/project.yaml
-# plan.yaml is runtime state — GitHub issues are the durable source of truth
 !.ratchet/pairs/
+# Tiebreaker rulings — precedents for future arbitration
+# (skills/run/SKILL.md Step 5d scans this on every run)
+!.ratchet/scores.yaml
+!.ratchet/escalations/
+!.ratchet/retros/
+!.ratchet/reviews/
+# plan.yaml is runtime state when using progress.adapter=github-issues (default).
+# Uncomment below if you use progress.adapter=markdown or none:
+# !.ratchet/plan.yaml
 
-# Ratchet workspaces: Exclude runtime state in all workspace subdirs
-*/.ratchet/worktrees/
-*/.ratchet/debates/
-*/.ratchet/reviews/
-*/.ratchet/scores/
-*/.ratchet/retros/
-*/.ratchet/escalations/
-*/.ratchet/guards/
-*/.ratchet/reports/
-*/.ratchet/progress/
-*/.ratchet/plan.yaml
-*/.ratchet/issues/
+# Debates: exclude transcripts (round-*.md, etc) but keep structured metadata.
+# Trick: we re-include the `debates/` dir AND `debates/*/` subdirs so git can
+# descend into them, then exclude the files within them, then whitelist meta.json.
+# (Git cannot re-include a file whose parent directory is excluded, so the
+# subdir must stay visible.)
+!.ratchet/debates/
+!.ratchet/debates/*/
+.ratchet/debates/*/*
+!.ratchet/debates/*/meta.json
+
+# Ratchet workspaces: symmetric rules for multi-workspace setups
+# (e.g., monitor/.ratchet/, worker/.ratchet/). Applies when a workspace
+# does not have its own .gitignore overriding these rules.
+*/.ratchet/*
+!*/.ratchet/workflow.yaml
+!*/.ratchet/project.yaml
+!*/.ratchet/pairs/
+!*/.ratchet/scores.yaml
+!*/.ratchet/escalations/
+!*/.ratchet/retros/
+!*/.ratchet/reviews/
+# !*/.ratchet/plan.yaml  # Uncomment if progress.adapter=markdown or none
+# Workspace debates: same transcript-excluded / meta-tracked pattern
+!*/.ratchet/debates/
+!*/.ratchet/debates/*/
+*/.ratchet/debates/*/*
+!*/.ratchet/debates/*/meta.json
 
 # Ratchet runtime state (auto-added by install.sh)
-.ratchet/plan.yaml
-.ratchet/debates/
-.ratchet/reviews/
-.ratchet/scores/
-.ratchet/retros/
-.ratchet/escalations/
 .ratchet/guards/
 .ratchet/reports/
 .ratchet/progress/

--- a/install.sh
+++ b/install.sh
@@ -98,8 +98,16 @@ remove_git_hook() {
 }
 
 setup_gitignore() {
-    # Add .ratchet/ runtime-state entries to .gitignore, then safely untrack
-    # any files that are now ignored but were previously committed.
+    # Add Ratchet gitignore block (exclude runtime state, whitelist
+    # institutional memory), then safely untrack any files that are now
+    # ignored but were previously committed.
+    #
+    # Philosophy: low-churn, high-value artifacts that agents need on a
+    # fresh clone (escalations/, retros/, reviews/, scores.yaml, and
+    # debates/*/meta.json) are whitelisted. High-churn runtime state
+    # (worktrees/, locks/, archive/, guards/, reports/, progress/,
+    # issues/, plan.yaml, and debate transcripts) stays excluded.
+    #
     # CRITICAL ORDER: gitignore entry MUST be written before git rm --cached,
     # otherwise git rm --cached removes the file from tracking without a safety
     # net and a subsequent commit could re-add it.
@@ -110,60 +118,81 @@ setup_gitignore() {
 
     local gitignore="$project_dir/.gitignore"
 
-    # Entries to ensure are present
     local marker="# Ratchet runtime state (auto-added by install.sh)"
-    local entries=(
-        ".ratchet/plan.yaml"
-        ".ratchet/debates/"
-        ".ratchet/reviews/"
-        ".ratchet/scores/"
-        ".ratchet/retros/"
-        ".ratchet/escalations/"
-        ".ratchet/guards/"
-        ".ratchet/reports/"
-        ".ratchet/progress/"
-        ".ratchet/worktrees/"
-        ".ratchet/locks/"
-        ".ratchet/archive/"
-        ".ratchet/issues/"
-    )
 
     # Check if marker is already present (idempotent)
     if grep -qF "$marker" "$gitignore" 2>/dev/null; then
         return 0
     fi
 
-    # Step 1 — Write gitignore entries FIRST (safety net before any untracking)
+    # Step 1 — Write gitignore entries FIRST (safety net before any untracking).
+    # The block uses the "exclude all, then whitelist" pattern so low-churn
+    # institutional memory survives fresh clones while noisy runtime state
+    # is kept out of the repo.
     {
         echo ""
         echo "$marker"
-        for entry in "${entries[@]}"; do
-            echo "$entry"
-        done
+        echo "# Exclude all runtime state, then whitelist institutional memory."
+        echo ".ratchet/*"
+        echo "!.ratchet/workflow.yaml"
+        echo "!.ratchet/project.yaml"
+        echo "!.ratchet/pairs/"
+        echo "# Tiebreaker rulings — precedents scanned by skills/run/SKILL.md Step 5d"
+        echo "!.ratchet/escalations/"
+        echo "# EMA quality metrics — needed for /ratchet:score trends"
+        echo "!.ratchet/scores.yaml"
+        echo "# Retrospective findings and agent performance reviews (Tighten reads these)"
+        echo "!.ratchet/retros/"
+        echo "!.ratchet/reviews/"
+        echo "# plan.yaml is runtime state when progress.adapter=github-issues (default)."
+        echo "# Uncomment below if you use progress.adapter=markdown or none:"
+        echo "# !.ratchet/plan.yaml"
+        echo ""
+        echo "# Debates: exclude transcripts (round-*.md) but keep structured metadata."
+        echo "# The debates/ dir and its subdirs must stay visible so meta.json can"
+        echo "# be whitelisted (git cannot re-include a file whose parent is excluded)."
+        echo "!.ratchet/debates/"
+        echo "!.ratchet/debates/*/"
+        echo ".ratchet/debates/*/*"
+        echo "!.ratchet/debates/*/meta.json"
+        echo ""
+        echo "# Runtime state that stays fully excluded"
+        echo ".ratchet/worktrees/"
+        echo ".ratchet/locks/"
+        echo ".ratchet/archive/"
+        echo ".ratchet/guards/"
+        echo ".ratchet/reports/"
+        echo ".ratchet/progress/"
+        echo ".ratchet/issues/"
     } >> "$gitignore" || { echo "Error: Failed to write to $gitignore" >&2; return 1; }
 
     echo "  Updated .gitignore with Ratchet runtime state entries"
 
     # Step 2 — Untrack any files that are now ignored but were previously committed.
-    # Run AFTER the gitignore is updated so the patterns are active.
+    # Run AFTER the gitignore is updated so the patterns are active. Only untrack
+    # entries that remain excluded; do NOT touch whitelisted institutional memory.
     local tracked_runtime=()
     while IFS= read -r tracked_file; do
         [ -n "$tracked_file" ] && tracked_runtime+=("$tracked_file")
     done < <(git -C "$project_dir" ls-files -- \
         ".ratchet/plan.yaml" \
-        ".ratchet/debates/" \
-        ".ratchet/reviews/" \
-        ".ratchet/scores/" \
-        ".ratchet/retros/" \
-        ".ratchet/escalations/" \
-        ".ratchet/guards/" \
-        ".ratchet/reports/" \
-        ".ratchet/progress/" \
         ".ratchet/worktrees/" \
         ".ratchet/locks/" \
         ".ratchet/archive/" \
+        ".ratchet/guards/" \
+        ".ratchet/reports/" \
+        ".ratchet/progress/" \
         ".ratchet/issues/" \
         2>/dev/null)
+
+    # Also untrack debate transcripts (everything under debates/*/ except meta.json)
+    while IFS= read -r tracked_file; do
+        [ -n "$tracked_file" ] || continue
+        case "$tracked_file" in
+            *"/meta.json") ;;  # keep metadata
+            *) tracked_runtime+=("$tracked_file") ;;
+        esac
+    done < <(git -C "$project_dir" ls-files -- ".ratchet/debates/" 2>/dev/null)
 
     if [ "${#tracked_runtime[@]}" -gt 0 ]; then
         git -C "$project_dir" rm --cached -- "${tracked_runtime[@]}" 2>/dev/null || \

--- a/monitor/.gitignore
+++ b/monitor/.gitignore
@@ -1,12 +1,21 @@
 /tui
 /monitor
 
-# Ratchet runtime artifacts (regenerable, environment-specific)
-.ratchet/debates/
-.ratchet/reviews/
+# Ratchet runtime artifacts (regenerable, environment-specific).
+# Low-churn institutional memory (escalations/, retros/, reviews/,
+# scores.yaml, debates/*/meta.json) is intentionally NOT listed here
+# so fresh clones retain hard-earned precedents and metrics.
 .ratchet/scores/
-.ratchet/retros/
-.ratchet/escalations/
 .ratchet/guards/
 .ratchet/reports/
 .ratchet/progress/
+.ratchet/worktrees/
+.ratchet/locks/
+.ratchet/archive/
+.ratchet/issues/
+.ratchet/plan.yaml
+
+# Debates: exclude transcripts but keep structured metadata (meta.json).
+# Files inside each debate subdir are excluded, then meta.json is whitelisted.
+.ratchet/debates/*/*
+!.ratchet/debates/*/meta.json


### PR DESCRIPTION
## Summary

Fix a gap in the ratchet gitignore strategy: low-churn, high-value state was being excluded on fresh clones, causing the project to "forget" institutional memory.

## What changes

**Newly tracked:**
- `escalations/` — tiebreaker rulings (precedents referenced by `skills/run/` Step 5d)
- `scores.yaml` — EMA-persisted quality metrics
- `retros/` — tighten retrospective findings
- `reviews/` — agent performance reviews
- `debates/*/meta.json` — debate verdicts/rounds/decided_by (small structured files)

**Still excluded:**
- `debates/*/round-*.md` — full transcripts (repo bloat)
- `plan.yaml` — still excluded by default (assumes `progress.adapter: github-issues`), but now with an opt-in comment for users of `markdown`/`none` adapters
- All the truly transient state (worktrees, locks, guards, progress cache, issues cache)

## Files changed

- `.gitignore` (root) — updated whitelist
- `monitor/.gitignore` — symmetric updates for multi-workspace setups (was independent, would have blocked the fix)
- `install.sh` — updated `setup_gitignore` template; pruned the untrack list so fresh installs onto existing repos don't destroy memory

## Non-obvious git semantics

The naive `!.ratchet/debates/*/meta.json` pattern can't re-include a file under an excluded parent. Required 4 rules in order: re-include `debates/` dir, re-include `debates/*/` subdirs, exclude `debates/*/*` files, then whitelist `meta.json`. Verified with `git check-ignore`.

## Test plan

- [x] `shellcheck install.sh` passes
- [x] `git check-ignore` verifies:
  - `workflow.yaml`, `project.yaml`, `pairs/*`, `scores.yaml`, `escalations/*`, `retros/*`, `reviews/*`, `debates/*/meta.json` → tracked
  - `debates/*/round-1.md`, `plan.yaml`, `guards/`, `reports/`, `progress/`, `worktrees/`, `locks/`, `archive/`, `issues/` → ignored
- [x] Multi-workspace (`monitor/.ratchet/`) symmetric behavior verified
- [x] Fresh install into tmp repo writes correct template
- [x] Idempotent on second install run (grep count = 1)
- [x] No regressions on currently-tracked files

## Rationale

See the analysis/debate in the conversation that produced this PR. Short version: escalations are precedents, scores are metrics, retros+reviews are tighten input signals. Losing them on clone is an institutional memory bug, not a design feature.

Deliberately NOT changing:
- No SQLite / event log / state branch rewrite (deferred — right answer long-term, wrong timing)
- No dynamic gitignore generation from adapter config (runtime coupling anti-pattern)
- No tracking full debate transcripts (repo bloat)